### PR TITLE
fix setAttribute ATTR_TIMEOUT when $this->_client is not initialized

### DIFF
--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -253,7 +253,7 @@ class PDO extends BasePDO implements PDOInterface
 
             case self::ATTR_TIMEOUT:
                 $this->attributes['timeout'] = (int)$value;
-                if(is_object($this->client)) {
+                if (is_object($this->client)) {
                     $this->client->setTimeout((int)$value);
                 }
                 break;


### PR DESCRIPTION
Hi,

Initializing crate PDO with timeout in the $options array throws and error:

``` php
$this->_pdo = new PDO('crate:' . $descriptor['host'] . ':' . $descriptor['port'], null, null, [
            PDO::ATTR_TIMEOUT => 100
        ]);
```

``` php
Fatal error: Call to a member function setTimeout() on a non-object in /opt/web/gitlab/php-jabol-logs/vendor/crate/crate-pdo/src/Crate/PDO/PDO.php on line 256 
```

because $this->_client is not initilized yet.
