### PR TITLE
fix Amp\Promise::wait() is deprecated and scheduled for removal.

### DIFF
--- a/src/Crate/PDO/ArtaxExt/Client.php
+++ b/src/Crate/PDO/ArtaxExt/Client.php
@@ -67,7 +67,7 @@ class Client implements ClientInterface
         $request->setBody(json_encode($body));
 
         $promise     = $this->client->request($request);
-        $response    = $promise->wait();
+        $response    = \Amp\wait($promise);
         $responseBody = json_decode($response->getBody(), true);
 
         if ($response->getStatus() !== 200) {


### PR DESCRIPTION
Amp\Promise::wait() is deprecated and scheduled for removal. Please update code to use Amp\wait($promise) instead

https://github.com/amphp/amp/releases/tag/v0.15.0

Release 0.15 removes Amp\Promise::wait()