### PR TITLE
nailed dependency versions of amphp/artax and amphp/amp

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@
 Unreleased
 ==========
 
+ - Nailed dependency versions of amphp/artax and amphp/amp
+   to prevent composer from fetching newer, incompatible releases
+
 2014/12/04 0.0.6
 ================
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "php":     "~5.5",
         "ext-pdo": "~1.0",
-        "amphp/artax": "~1.0.0-rc2"
+        "amphp/amp": "0.12",
+        "amphp/artax": "1.0.0-rc4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
to prevent composer from fetching newer, incompatible releases
