### PR TITLE
Update year in copyright license: Trello #693

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 CRATE PDO Adapter
-Copyright 2014 CRATE Technology GmbH ("Crate")
+Copyright 2014-2015 CRATE Technology GmbH ("Crate")
 
 Licensed to CRATE Technology GmbH (referred to in this notice as "Crate")
 under one or more contributor license agreements.  See the NOTICE file

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 CRATE PDO Adapter
-Copyright 2014 CRATE Technology GmbH ("Crate")
+Copyright 2014-2015 CRATE Technology GmbH ("Crate")
 
 Third party dependencies:
 


### PR DESCRIPTION
The year in the license file needed to be updated to include 2015