### PR TITLE
make possible to use http basic auth with guzzle http client

### DIFF
--- a/src/Crate/PDO/Http/Client.php
+++ b/src/Crate/PDO/Http/Client.php
@@ -106,4 +106,12 @@ class Client implements ClientInterface
     {
         $this->client->setDefaultOption('timeout', (float) $timeout);
     }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function setHttpBasicAuth($username, $passwd)
+    {
+        $this->client->setDefaultOption('auth', [$username, $passwd]);
+    }
 }

--- a/src/Crate/PDO/Http/ClientInterface.php
+++ b/src/Crate/PDO/Http/ClientInterface.php
@@ -36,6 +36,16 @@ interface ClientInterface
     public function setTimeout($timeout);
 
     /**
+     * Set the connection http basic auth
+     *
+     * @param string $username
+     * @param string $passwd
+     *
+     * @return void
+     */
+    public function setHttpBasicAuth($username, $passwd);
+
+    /**
      * Execute the PDOStatement and return the response from server
      * wrapped inside a Collection
      *

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -82,10 +82,15 @@ class PDO extends BasePDO implements PDOInterface
 
         $servers = self::parseDSN($dsn);
         $uri     = self::computeURI($servers[0]);
+        $params = [
+            'timeout' => $this->attributes['timeout'],
+        ];
 
-        $this->client = new Http\Client($uri, [
-            'timeout' => $this->attributes['timeout']
-        ]);
+        if (!empty($username) && !empty($passwd)) {
+            $params['defaults'] = ['auth' => [$username, $passwd]];
+        }
+
+        $this->client = new Http\Client($uri, $params);
 
         // Define a callback that will be used in the PDOStatements
         // This way we don't expose this as a public api to the end users.

--- a/test/CrateIntegrationTest/PDO/AbstractIntegrationTest.php
+++ b/test/CrateIntegrationTest/PDO/AbstractIntegrationTest.php
@@ -34,7 +34,7 @@ abstract class AbstractIntegrationTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->pdo = new PDO('crate:localhost:4200', null, null, []);
+        $this->pdo = new PDO('crate:staging.crate.data.meinauto.de:80', 'elasticsearch', 'ohvu3yVFGqer9IuQ8820sJMf2rw6s1Hs3vQiUB9l4mI=', []);
         $query = 'CREATE TABLE test_table (id INTEGER PRIMARY KEY, name STRING,';
         $query .= 'int_type INTEGER, long_type LONG, boolean_type BOOLEAN,';
         $query .= 'double_type DOUBLE, float_type FLOAT, array_type ARRAY(INTEGER),';

--- a/test/CrateIntegrationTest/PDO/AbstractIntegrationTest.php
+++ b/test/CrateIntegrationTest/PDO/AbstractIntegrationTest.php
@@ -34,7 +34,7 @@ abstract class AbstractIntegrationTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->pdo = new PDO('crate:staging.crate.data.meinauto.de:80', 'elasticsearch', 'ohvu3yVFGqer9IuQ8820sJMf2rw6s1Hs3vQiUB9l4mI=', []);
+        $this->pdo = new PDO('crate:localhost:4200', null, null, []);
         $query = 'CREATE TABLE test_table (id INTEGER PRIMARY KEY, name STRING,';
         $query .= 'int_type INTEGER, long_type LONG, boolean_type BOOLEAN,';
         $query .= 'double_type DOUBLE, float_type FLOAT, array_type ARRAY(INTEGER),';

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -100,10 +100,18 @@ class PDOTest extends PHPUnit_Framework_TestCase
      */
     public function testInstantiationWithHttpBasicAuth()
     {
-        $pdo = new PDO('crate:localhost:1234', 'user', 'passwd', []);
+        $user = 'user';
+        $passwd = 'passwd';
+        $expectedCredentials = [$user, $passwd];
 
-        $this->assertInstanceOf('Crate\PDO\PDO', $pdo);
-        $this->assertInstanceOf('PDO', $pdo);
+        $this->client
+            ->expects($this->once())
+            ->method('setHttpBasicAuth')
+            ->with($user, $passwd);
+
+        $this->pdo->setAttribute(PDO::ATTR_HTTP_AUTH, [$user, $passwd]);
+
+        $this->assertEquals($expectedCredentials, $this->pdo->getAttribute(PDO::ATTR_HTTP_AUTH));
     }
 
     /**

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -96,6 +96,17 @@ class PDOTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::__construct
+     */
+    public function testInstantiationWithHttpBasicAuth()
+    {
+        $pdo = new PDO('crate:localhost:1234', 'user', 'passwd', []);
+
+        $this->assertInstanceOf('Crate\PDO\PDO', $pdo);
+        $this->assertInstanceOf('PDO', $pdo);
+    }
+
+    /**
      * @covers ::getAttribute
      */
     public function testGetAttributeWithInvalidAttribute()


### PR DESCRIPTION
with credentials from doctrine dbal connnection parameters user and password
@see: http://guzzle.readthedocs.org/en/latest/clients.html
@see: http://doctrine-dbal.readthedocs.org/en/latest/reference/configuration.html