### PR TITLE
make possible to use http basic auth with guzzle http client at Crate/PDO

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,12 @@
 Unreleased
 ==========
 
+2015/05/06 0.1.1
+================
+
+ - Support guzzle http basic auth at Crate/PDO through doctrine
+   dbal connection user credetials
+
 2015/01/08 0.1.0
 ================
 

--- a/src/Crate/PDO/Http/Client.php
+++ b/src/Crate/PDO/Http/Client.php
@@ -106,4 +106,12 @@ class Client implements ClientInterface
     {
         $this->client->setDefaultOption('timeout', (float) $timeout);
     }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function setHttpBasicAuth($username, $passwd)
+    {
+        $this->client->setDefaultOption('auth', [$username, $passwd]);
+    }
 }

--- a/src/Crate/PDO/Http/ClientInterface.php
+++ b/src/Crate/PDO/Http/ClientInterface.php
@@ -36,6 +36,16 @@ interface ClientInterface
     public function setTimeout($timeout);
 
     /**
+     * Set the connection http basic auth
+     *
+     * @param string $username
+     * @param string $passwd
+     *
+     * @return void
+     */
+    public function setHttpBasicAuth($username, $passwd);
+
+    /**
      * Execute the PDOStatement and return the response from server
      * wrapped inside a Collection
      *

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -33,6 +33,8 @@ class PDO extends BasePDO implements PDOInterface
 
     const DSN_REGEX = '/^(?:crate)?(?::([\w\d\.-]+:\d+))+/';
 
+    const ATTR_HTTP_BASIC_AUTH    = 403;
+
     const PARAM_FLOAT       = 6;
     const PARAM_DOUBLE      = 7;
     const PARAM_LONG        = 8;
@@ -48,7 +50,8 @@ class PDO extends BasePDO implements PDOInterface
         'defaultFetchMode' => self::FETCH_BOTH,
         'errorMode'        => self::ERRMODE_SILENT,
         'statementClass'   => 'Crate\PDO\PDOStatement',
-        'timeout'          => 5.0
+        'timeout'          => 5.0,
+        'auth'             => []
     ];
 
     /**
@@ -86,6 +89,10 @@ class PDO extends BasePDO implements PDOInterface
         $this->client = new Http\Client($uri, [
             'timeout' => $this->attributes['timeout']
         ]);
+
+        if (!empty($username) && !empty($passwd)) {
+            $this->client->setHttpBasicAuth($username, $passwd);
+        }
 
         // Define a callback that will be used in the PDOStatements
         // This way we don't expose this as a public api to the end users.
@@ -260,6 +267,14 @@ class PDO extends BasePDO implements PDOInterface
                 }
                 break;
 
+            case self::ATTR_HTTP_BASIC_AUTH:
+                $this->attributes['auth'] = $value;
+                if (is_object($this->client) && is_array($value)) {
+                    list($user, $password) = $value;
+                    $this->client->setHttpBasicAuth($user, $password);
+                }
+                break;
+            
             default:
                 throw new Exception\PDOException('Unsupported driver attribute');
         }
@@ -288,6 +303,9 @@ class PDO extends BasePDO implements PDOInterface
 
             case PDO::ATTR_TIMEOUT:
                 return $this->attributes['timeout'];
+
+            case PDO::ATTR_HTTP_BASIC_AUTH:
+                return $this->attributes['auth'];
 
             case PDO::ATTR_DEFAULT_FETCH_MODE:
                 return $this->attributes['defaultFetchMode'];

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -96,6 +96,25 @@ class PDOTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::__construct
+     */
+    public function testSetAttributeWithHttpBasicAuth()
+    {
+        $user = 'user';
+        $passwd = 'passwd';
+        $expectedCredentials = [$user, $passwd];
+
+        $this->client
+            ->expects($this->once())
+            ->method('setHttpBasicAuth')
+            ->with($user, $passwd);
+
+        $this->pdo->setAttribute(PDO::ATTR_HTTP_BASIC_AUTH, [$user, $passwd]);
+
+        $this->assertEquals($expectedCredentials, $this->pdo->getAttribute(PDO::ATTR_HTTP_BASIC_AUTH));
+    }
+
+    /**
      * @covers ::getAttribute
      */
     public function testGetAttributeWithInvalidAttribute()


### PR DESCRIPTION
Ok thanks for the last reply. I hope this will work for you.
Test added and asserted the http client parameters given for Crate/PDO.
with credentials from doctrine dbal connnection parameters user and password
@see: http://guzzle.readthedocs.org/en/latest/clients.html
@see: http://doctrine-dbal.readthedocs.org/en/latest/reference/configuration.html
