### PR TITLE
set auth attribute in constructor of PDO class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@
 Unreleased
 ==========
 
+ - Set auth attribute in constructor of PDO class if credentials
+   are available
+
 2015/05/07 0.2.0
 ================
 

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -91,7 +91,7 @@ class PDO extends BasePDO implements PDOInterface
         ]);
 
         if (!empty($username) && !empty($passwd)) {
-            $this->client->setHttpBasicAuth($username, $passwd);
+            $this->setAttribute(PDO::ATTR_HTTP_BASIC_AUTH, [$username, $passwd]);
         }
 
         // Define a callback that will be used in the PDOStatements
@@ -274,7 +274,7 @@ class PDO extends BasePDO implements PDOInterface
                     $this->client->setHttpBasicAuth($user, $password);
                 }
                 break;
-            
+
             default:
                 throw new Exception\PDOException('Unsupported driver attribute');
         }

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -98,20 +98,35 @@ class PDOTest extends PHPUnit_Framework_TestCase
     /**
      * @covers ::__construct
      */
+    public function testInstantiationWithHttpAuth() {
+        $user = 'crate';
+        $passwd = 'secret';
+        $pdo = new PDO('crate:localhost:44200', $user, $passwd, []);
+        $this->assertEquals([$user, $passwd], $pdo->getAttribute(PDO::ATTR_HTTP_BASIC_AUTH));
+    }
+
+    /**
+     * @covers ::setAttribute
+     */
     public function testSetAttributeWithHttpBasicAuth()
     {
-        $user = 'user';
-        $passwd = 'passwd';
+        $user = 'crate';
+        $passwd = 'secret';
         $expectedCredentials = [$user, $passwd];
 
-        $this->client
+        $client = $this->getMock(ClientInterface::class);
+        $pdo = new PDO('crate:localhost:44200', null, null, []);
+        $reflection = new ReflectionClass(PDO::class);
+        $property = $reflection->getProperty('client');
+        $property->setAccessible(true);
+        $property->setValue($pdo, $client);
+        $client
             ->expects($this->once())
             ->method('setHttpBasicAuth')
             ->with($user, $passwd);
 
-        $this->pdo->setAttribute(PDO::ATTR_HTTP_BASIC_AUTH, [$user, $passwd]);
-
-        $this->assertEquals($expectedCredentials, $this->pdo->getAttribute(PDO::ATTR_HTTP_BASIC_AUTH));
+        $pdo->setAttribute(PDO::ATTR_HTTP_BASIC_AUTH, [$user, $passwd]);
+        $this->assertEquals($expectedCredentials, $pdo->getAttribute(PDO::ATTR_HTTP_BASIC_AUTH));
     }
 
     /**


### PR DESCRIPTION
if credentials are available
previously only the client auth credentials were set in constructor