### PR TITLE
Bind PDO values with correct type.

### DIFF
--- a/src/Crate/PDO/PDOStatement.php
+++ b/src/Crate/PDO/PDOStatement.php
@@ -202,7 +202,10 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
             if (is_int($parameter) && $zero_based) {
                 $parameter++;
             }
-            $this->bindValue($parameter, $value);
+            // to correctly save arrays and objects, we need to pass
+            // parameter type
+            $dataType = $this->guessDataType($parameter, $value);
+            $this->bindValue($parameter, $value, $dataType);
         }
 
         $result = $this->request->__invoke($this, $this->sql, $this->parameters);
@@ -216,6 +219,29 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
 
         $this->collection = $result;
         return true;
+    }
+    
+    /**
+     * Returns PDO::PARAM_* type based on parameter value.
+     */
+    protected function guessDataType($parameter, $value) 
+    {
+        switch (gettype($value)) {
+            case 'array':
+                return PDO::PARAM_ARRAY;
+            case 'object':
+                return PDO::PARAM_OBJECT;
+            case 'double':
+                return PDO::PARAM_DOUBLE;
+            case 'boolean':
+                return PDO::PARAM_BOOL;
+            case 'NULL':
+                return PDO::PARAM_NULL;
+            case 'integer':
+                return PDO::PARAM_LONG;
+            default:
+                return PDO::PARAM_STR;
+        }
     }
 
     /**


### PR DESCRIPTION
Currently pdo binds all parameters as PDO::PARAM_STR. This produces
an error when user wants to bind array to an array field (or object
to an object field).

This patch sends correct dataType to bindValue() method.
