### PR TITLE
Proposing docs version change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Installation
 
 Install the library by adding it to your composer.json or running::
 
-    php composer.phar require crate/crate-pdo:~0.0.3
+    php composer.phar require crate/crate-pdo:~0.3.0
 
 DSN
 ===


### PR DESCRIPTION
I'd like to propose this small change to the docs.

If you installed with the version recommended Composer would install version 0.0.6, which is quite old and the user would see lots of disclaimer messages about other dependencies being out of date. Using this version means people are up to date and installation is smooth.