### PR TITLE
added support for PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
   - hhvm-nightly
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -19,6 +19,19 @@ Start up the vagrant machine, when run for the first time it will also run the n
 
     vagrant up
 
+PHP Version
+-----------
+
+There are 2 PHP versions installed in the Vagrant box: ``5.6.3`` and ``7.0.2``.
+To activate a certain version you need to create a symlink to ``php5`` or ``php7``
+in ``/usr/bin/``::
+
+    sudo rm /usr/bin/php
+    sudo ln -s /usr/bin/phpX /usr/bin/php
+
+Installing dependencies
+-----------------------
+
 Get composer & install dependencies::
 
     vagrant ssh

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "homepage": "https://github.com/crate/crate-pdo",
     "keywords": ["database", "pdo", "crate"],
     "require": {
-        "php":     "~5.5",
-        "ext-pdo": "~1.0",
+        "php":     "~5.5|~7.0",
+        "ext-pdo": "*",
         "guzzlehttp/guzzle": "~5.0"
     },
     "autoload": {

--- a/provisioning.sh
+++ b/provisioning.sh
@@ -1,8 +1,21 @@
 #!/bin/sh
-wget -O - http://dl.hhvm.com/conf/hhvm.gpg.key | sudo apt-key add -
-echo deb http://dl.hhvm.com/ubuntu trusty main | sudo tee /etc/apt/sources.list.d/hhvm.list
-sudo apt-get update
-sudo apt-get install -y python-software-properties
-sudo add-apt-repository -y ppa:crate/stable
-sudo apt-get update
-sudo apt-get install -y crate hhvm php5-cli php5-xdebug
+apt-get update
+apt-get install -y python-software-properties
+add-apt-repository -y ppa:crate/stable
+apt-get update
+apt-get install -y crate git libmcrypt-dev libreadline-dev
+apt-get build-dep -y php5-cli
+
+git clone git://github.com/php-build/php-build && cd php-build && ./install.sh
+
+php-build -i development 5.6.3 /usr/local/php/5.6.3
+ln -s /usr/local/php/5.6.3/bin/php /usr/bin/php5.6
+ln -s /usr/bin/php5.6 /usr/bin/php5
+
+php-build -i development 7.0.2 /usr/local/php/7.0.2
+ln -s /usr/local/php/7.0.2/bin/php /usr/bin/php7.0
+ln -s /usr/bin/php7.0 /usr/bin/php7
+
+# default to php7
+ln -s /usr/bin/php7.0 /usr/bin/php
+


### PR DESCRIPTION
In the Vagrantbox use [php-build](https://php-build.github.io/) to allow installing multiple versions of PHP in parallel. These versions can be used e.g. as remote interpreter in IntelliJ or other IDEs.