### PR TITLE
support for multiple servers in DSN connection string

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@
 Unreleased
 ==========
 
+ - Support for multiple hosts in DSN connection string
+
  - Added support for using a default schema in PDO connection
    via ``/schema`` suffix in connection string
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,13 +29,15 @@ DSN
 
 Following DSN is supported::
 
-    crate:<HOSTNAME_OR_IP>:<PORT>[/<SCHEMA>]
+    crate:<HOSTNAME_OR_IP>:<PORT>[,<HOSTNAME_OR_IP>:<PORT>,...][/<SCHEMA>]
 
 Examples::
 
     crate:localhost:4200
     crate:127.0.0.1:4200
+    crate:c1.example.com:4200,c2.example.com:4200,c3.example.com:4200
     crate:demo.crate.io:4200/my_schema
+    crate:demo1.crate.io:4200,demo2.crate.io:4200/my_schema
 
 The ``/schema`` part in the connection string is optional and can be omitted.
 If no schema is provided the Crate's default schema ``doc`` is used.

--- a/src/Crate/PDO/Http/InternalClientInterface.php
+++ b/src/Crate/PDO/Http/InternalClientInterface.php
@@ -22,19 +22,45 @@
 
 namespace Crate\PDO\Http;
 
-use Crate\Stdlib\CollectionInterface;
-
-interface ClientInterface extends InternalClientInterface
+interface InternalClientInterface
 {
 
     /**
-     * Execute the PDOStatement and return the response from server
-     * wrapped inside a Collection
+     * Set the connection timeout
      *
-     * @param string       $queryString
-     * @param array        $parameters
+     * @param int $timeout
      *
-     * @return CollectionInterface|null
+     * @return void
      */
-    public function execute($queryString, array $parameters);
+    public function setTimeout($timeout);
+
+    /**
+     * Set the connection http basic auth
+     *
+     * @param string $username
+     * @param string $passwd
+     *
+     * @return void
+     */
+    public function setHttpBasicAuth($username, $passwd);
+
+    /**
+     * @return array
+     */
+    public function getServerInfo();
+
+    /**
+     * @return string
+     */
+    public function getServerVersion();
+
+    /**
+     * Set HTTP header for client requests
+     *
+     * @param string       $name
+     * @param string       $value
+     *
+     * @return void
+     */
+    public function setHttpHeader($name, $value);
 }

--- a/src/Crate/PDO/Http/Server.php
+++ b/src/Crate/PDO/Http/Server.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Licensed to CRATE Technology GmbH("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+namespace Crate\PDO\Http;
+
+use Crate\PDO\Exception\UnsupportedException;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Message\ResponseInterface;
+
+class Server implements InternalClientInterface
+{
+
+    const PROTOCOL = 'http';
+    const SQL_PATH = '/_sql';
+
+    /**
+     * @var HttpClient
+     */
+    private $client;
+
+    /**
+     * @param string $uri
+     * @param array  $options
+     */
+    public function __construct($uri, array $options)
+    {
+        $uri = self::computeURI($uri);
+        $this->client = new HttpClient(['base_url' => $uri] + $options);
+    }
+
+    public function setTimeout($timeout)
+    {
+        $this->client->setDefaultOption('timeout', (float) $timeout);
+    }
+
+    public function setHttpBasicAuth($username, $passwd)
+    {
+        $this->client->setDefaultOption('auth', [$username, $passwd]);
+    }
+
+    public function setHttpHeader($name, $value)
+    {
+        $this->client->setDefaultOption('headers/'.$name, $value);
+    }
+
+    public function getServerInfo()
+    {
+        // TODO: Implement getServerInfo() method.
+        throw new UnsupportedException('Not yet implemented');
+    }
+
+    public function getServerVersion()
+    {
+        // TODO: Implement getServerVersion() method.
+        throw new UnsupportedException('Not yet implemented');
+    }
+
+    /**
+     * Execute a HTTP/1.1 POST request with JSON body
+     *
+     * @param array $body
+
+     * @return ResponseInterface
+     * @throws RequestException When an error is encountered
+     */
+    public function doRequest(array $body)
+    {
+        return $this->client->post(null, ['json' => $body]);
+    }
+
+    /**
+     * Compute a URI for usage with the HTTP client
+     *
+     * @param string $server A host:port string
+     *
+     * @return string An URI which can be used by the HTTP client
+     */
+    private static function computeURI($server)
+    {
+        return self::PROTOCOL .'://' . $server . self::SQL_PATH;
+    }
+}

--- a/test/CrateTest/PDO/Http/ServerTest.php
+++ b/test/CrateTest/PDO/Http/ServerTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: christian
+ * Date: 15/01/16
+ * Time: 08:19
+ */
+
+namespace CrateTest\PDO\Http;
+
+use Crate\PDO\Exception\UnsupportedException;
+use Crate\PDO\Http\Server;
+use GuzzleHttp\ClientInterface as HttpClientInterface;
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+
+/**
+ * Class ServerTest
+ *
+ * @coversDefaultClass \Crate\PDO\Http\Server
+ * @covers ::<!public>
+ *
+ * @group unit
+ */
+class ServerTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Server $client
+     */
+    private $server;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $client;
+
+    /**
+     * @covers ::__construct
+     */
+    protected function setUp()
+    {
+        $this->server = new Server('http://localhost:4200/_sql', []);
+        $this->client = $this->getMock(HttpClientInterface::class);
+
+        $reflection = new ReflectionClass($this->server);
+        $property = $reflection->getProperty('client');
+        $property->setAccessible(true);
+        $property->setValue($this->server, $this->client);
+    }
+
+    /**
+     * @covers ::getServerInfo
+     */
+    public function testGetServerInfo()
+    {
+        $this->setExpectedException(UnsupportedException::class);
+        $this->server->getServerInfo();
+    }
+
+    /**
+     * @covers ::getServerVersion
+     */
+    public function testGetServerVersion()
+    {
+        $this->setExpectedException(UnsupportedException::class);
+        $this->server->getServerVersion();
+    }
+
+    /**
+     * @covers ::setTimeout
+     */
+    public function testSetTimeout()
+    {
+        $this->client
+            ->expects($this->once())
+            ->method('setDefaultOption')
+            ->with('timeout', 4);
+
+        $this->server->setTimeout('4');
+    }
+
+    /**
+     * @covers ::setHTTPHeader
+     */
+    public function testSetHTTPHeader()
+    {
+        $schema = 'my_schema';
+        $schemaHeader = 'Default-Schema';
+
+        $this->client
+            ->expects($this->once())
+            ->method('setDefaultOption')
+            ->with('headers/'.$schemaHeader, $schema);
+
+        $this->server->setHttpHeader($schemaHeader, $schema);
+
+        $server = new Server('http://localhost:4200/_sql', []);
+        $reflection = new ReflectionClass($server);
+        $property = $reflection->getProperty('client');
+        $property->setAccessible(true);
+
+        $server->setHttpHeader($schemaHeader, $schema);
+        $internalClient = $property->getValue($server);
+        $header = $internalClient->getDefaultOption('headers/'.$schemaHeader);
+
+        $this->assertEquals($schema, $header);
+    }
+
+}

--- a/test/CrateTest/PDO/PDOParseDSNTest.php
+++ b/test/CrateTest/PDO/PDOParseDSNTest.php
@@ -33,17 +33,33 @@ class PDOParseDSNTest extends PHPUnit_Framework_TestCase
     {
         $method = new ReflectionMethod('Crate\PDO\PDO', 'parseDSN');
         $method->setAccessible(true);
-
         return $method->invoke(null, $dsn);
+    }
+
+    private function serversFromDsnParts(array $dsnParts)
+    {
+        $method = new ReflectionMethod('Crate\PDO\PDO', 'serversFromDsnParts');
+        $method->setAccessible(true);
+        return $method->invoke(null, $dsnParts);
     }
 
     public function testParseDSNSingleHost()
     {
-        $dsn = 'crate:localhost:4200';
-        $servers = $this->parseDSN($dsn);
+        $parts = $this->parseDSN('crate:localhost:4200');
+        $servers = $this->serversFromDsnParts($parts);
 
         $this->assertEquals(1, count($servers));
         $this->assertEquals('localhost:4200', $servers[0]);
+    }
+
+    public function testParseDSNMultipleHosts()
+    {
+        $parts = $this->parseDSN('crate:crate1.example.com:4200,crate2.example.com:4200');
+        $servers = $this->serversFromDsnParts($parts);
+
+        $this->assertEquals(2, count($servers));
+        $this->assertEquals('crate1.example.com:4200', $servers[0]);
+        $this->assertEquals('crate2.example.com:4200', $servers[1]);
     }
 
     public function testParseDSNMissingName()


### PR DESCRIPTION
Add support for multiple `host:ip` pairs in DSN connection string:
```
crate:<HOSTNAME_OR_IP>:<PORT>[,<HOSTNAME_OR_IP>:<PORT>,...][/<SCHEMA>]
```
This will generate a pool of available servers. Each `execute()` will select the next available server from the pool and perform the HTTP request on that server. If a server is not reachable any more, it will be removed from the list of available servers.