### PR TITLE
Sort parameters array before use in request

### DIFF
--- a/src/Crate/PDO/PDOStatement.php
+++ b/src/Crate/PDO/PDOStatement.php
@@ -205,6 +205,9 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
             $this->bindValue($parameter, $value);
         }
 
+        // Sort parameters by key so that [1 => 'b', 0 => 'a'] becomes just ['a', 'b']
+        // If this isn't done, json_encode creates {"1" : "b", "0" : "a"} instead of ["a", "b"]
+        ksort($this->parameters);
         $result = $this->request->__invoke($this, $this->sql, $this->parameters);
 
         if (is_array($result)) {


### PR DESCRIPTION
Sometimes when PDO parameters are provided to the `exec()` method, the array may have positional arguments specified out of order with the statement. For instance:

```php
$pdo = new \Crate\PDO\PDO('crate:127.0.0.1:4200');
$stmt = $pdo->prepare('UPDATE schema.table SET colA = :colA WHERE colB = :colB');
$stmt->execute(['colB' => 'valB', 'colA' => 'valA']);
```

Without the above line, the above code would lead to the core server choking since the parameter bag will be an object rather than an array:

```
SQLActionException[
    Failed to parse source [{
        "stmt" : "UPDATE schema.table SET colA = ? WHERE colB = ?",
        "args" : {"1" : "valB", "0" : "valA"}
    }]
]
```

This happens when the `json_encode` function (used internally by GuzzleHTTP) receives an array with numerical keys that aren't in order:

```php
echo json_encode([0 => 'a', 1 => 'b']); // gives '["a","b"]'
echo json_encode([1 => 'b', 0 => 'a']); // gives '{"1":"b","0":"a"}'
```

Logically speaking, the above arrays should be equivalent but the core server can't handle the latter syntax. Providing the arguments out of order in this way is not necessarily malicious as there are no prescriptions or restrictions that prevent it from happening.