### PR TITLE
order parameter binding before pass to execute

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@
 Unreleased
 ==========
 
+ - Fixed an issue that occur if parameters are passed in a different order 
+   than specified in the sql statement.
+
 2016/06/20 0.5.0
 ================
 

--- a/src/Crate/PDO/PDOStatement.php
+++ b/src/Crate/PDO/PDOStatement.php
@@ -205,6 +205,9 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
             $this->bindValue($parameter, $value);
         }
 
+        // parameter binding might be unordered, so sort it before execute
+        ksort($this->parameters);
+
         $result = $this->request->__invoke($this, $this->sql, $this->parameters);
 
         if (is_array($result)) {

--- a/test/CrateIntegrationTest/PDO/PDOStatementTest.php
+++ b/test/CrateIntegrationTest/PDO/PDOStatementTest.php
@@ -263,4 +263,20 @@ class PDOStatementTest extends AbstractIntegrationTest
         $this->assertEquals([1, 2], $resultSet[0]['array_type']);
         $this->assertEquals(["foo" => "bar"], $resultSet[0]['object_type']);
     }
+
+    public function testUnorderedBindValue()
+    {
+        $this->insertRows(2);
+
+        $statement = $this->pdo->prepare('UPDATE test_table SET name = concat(name, :name) where id = :id');
+        $statement->bindValue(':id', 1);
+        $statement->bindValue(':name', '_abc');
+        $statement->execute();
+
+        $this->pdo->exec('REFRESH TABLE test_table');
+
+        $statement = $this->pdo->prepare('SELECT name FROM test_table WHERE ID=1');
+        $resultSet = $statement->fetch();
+        $this->assertEquals('hello world_abc', $resultSet[0]);
+    }
 }


### PR DESCRIPTION
fixed an issue that occur if parameters are passed in a different order
than in the sql statement specified.