### PR TITLE
fixed problem with parameter substitution

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,10 +5,13 @@
 Unreleased
 ==========
 
+ - Fix: having the same named parameter multiple times in a prepared SQL
+   statement caused incorrect parameter substitution with bound values
+
 2016/07/01 0.5.1
 ================
 
- - Fixed an issue that occur if parameters are passed in a different order 
+ - Fixed an issue that occur if parameters are passed in a different order
    than specified in the sql statement.
 
 2016/06/20 0.5.0

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -42,6 +42,9 @@ Get composer & install dependencies::
     curl -sS https://getcomposer.org/installer | php
     ./composer.phar install
 
+or if environment is outdated::
+
+    ./composer.phar update
 
 Running the tests
 =================

--- a/test/CrateTest/PDO/PDOStatementTest.php
+++ b/test/CrateTest/PDO/PDOStatementTest.php
@@ -900,8 +900,25 @@ class PDOStatementTest extends PHPUnit_Framework_TestCase
         $sql_converted = $method->invoke($this->statement, $sql);
         $this->assertEquals("select * from test_table where name = ? and hoschi = 'sld''fn:sdfsf' and id = ?", $sql_converted);
         $nameToPositionalMap = $property->getValue($this->statement);
-        $this->assertEquals(0, $nameToPositionalMap['name']);
-        $this->assertEquals(1, $nameToPositionalMap['id']);
+        $this->assertEquals("name", $nameToPositionalMap[1]);
+        $this->assertEquals("id", $nameToPositionalMap[2]);
     }
+    
+    public function testReplaceNamedParametersWithPositionalsMultiple()
+    {
+        $method = new ReflectionMethod('Crate\PDO\PDOStatement', 'replaceNamedParametersWithPositionals');
+        $method->setAccessible(true);
+        $property = new ReflectionProperty('Crate\PDO\PDOStatement', 'namedToPositionalMap');
+        $property->setAccessible(true);
+
+        $sql = "update test_table set name = concat(name, :name) where id = :id and name != :name";
+        $sql_converted = $method->invoke($this->statement, $sql);
+        $this->assertEquals("update test_table set name = concat(name, ?) where id = ? and name != ?", $sql_converted);
+        $nameToPositionalMap = $property->getValue($this->statement);
+        $this->assertEquals("name", $nameToPositionalMap[1]);
+        $this->assertEquals("id", $nameToPositionalMap[2]);
+        $this->assertEquals("name", $nameToPositionalMap[3]);
+    }
+    
 }
 


### PR DESCRIPTION
when same named parameter was present in prepared sql statement

fixes for example:
```sql
UPDATE mytable SET field = concat(field, :field) WHERE id = :id AND otherfield != :field
```

reported in: https://github.com/crate/crate/issues/3734