### PR TITLE
set default request timeout to 0 (indefinitely)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,10 +5,12 @@
 Unreleased
 ==========
 
+ - Changed default request timeout to ``0`` (indefinitely)
+
 2016/11/04 0.6.0
 ================
 
- - Expose `getServerVersion()` and `getServerInfo()` on the PDO implementation
+ - Expose ``getServerVersion()`` and ``getServerInfo()`` on the PDO implementation
    which return the version number of the Crate server connected to.
 
  - Fix: having the same named parameter multiple times in a prepared SQL

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -55,6 +55,20 @@ Note that you can still implicitly provide a schema in SQL statements, e.g.:
     used.
 
 
+Timeout
+=======
+
+Crate-PDO uses the `CrateDB HTTP protocol`_. Setting the PDO attribute
+``PDO::ATTR_TIMEOUT`` will raise a timeout exception and cancel the HTTP request
+after the specified time has elapsed. Cancelling the HTTP connection, however,
+does not cancel/kill the executed statement on the server.
+
+The following setting specifies the request timeout duration in seconds:
+
+**PDO::ATTR_TIMEOUT** (int)
+    | *Default-Value:*    ``0`` (indefinitely)
+
+
 Fetch Modes
 ===========
 
@@ -93,7 +107,7 @@ database handle (see `PDO::setAttribute`_).
     user name and password when making a request.
 
 **PDO::CRATE_ATTR_DEFAULT_SCHEMA** (string)
-    | *Default-Value*    ``doc``
+    | *Default-Value:*    ``doc``
 
     Set the default schema for the PDO connection.
 
@@ -101,3 +115,4 @@ database handle (see `PDO::setAttribute`_).
 .. _`PDO API Documentation`: http://www.php.net/pdo
 .. _DSN: https://en.wikipedia.org/wiki/Data_source_name
 .. _`PDO::setAttribute`: http://php.net/manual/en/pdo.setattribute.php
+.. _`CrateDB HTTP protocol`: https://crate.io/docs/reference/en/latest/protocols/http.html

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -56,7 +56,7 @@ class PDO extends BasePDO implements PDOInterface
         'defaultFetchMode' => self::FETCH_BOTH,
         'errorMode'        => self::ERRMODE_SILENT,
         'statementClass'   => 'Crate\PDO\PDOStatement',
-        'timeout'          => 5.0,
+        'timeout'          => 0.0,
         'auth'             => [],
         'defaultSchema'    => 'doc'
     ];

--- a/test/CrateIntegrationTest/PDO/PDOTest.php
+++ b/test/CrateIntegrationTest/PDO/PDOTest.php
@@ -70,6 +70,6 @@ class PDOTest extends AbstractIntegrationTest
     public function testGetServerVersion()
     {
         $result = $this->pdo->getServerVersion();
-        $this->assertEquals("0.56.3", $result);
+        $this->assertRegExp("/[0-9]+\.[0-9]+\.[0-9]+/", $result);
     }
 }

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -258,7 +258,7 @@ class PDOTest extends PHPUnit_Framework_TestCase
             ->method('setTimeout')
             ->with($timeout);
 
-        $this->assertEquals(5, $this->pdo->getAttribute(PDO::ATTR_TIMEOUT));
+        $this->assertEquals(0, $this->pdo->getAttribute(PDO::ATTR_TIMEOUT));
 
         $this->pdo->setAttribute(PDO::ATTR_TIMEOUT, $timeout);
 


### PR DESCRIPTION
0 is the default timeout of GuzzlePHP library.
http://docs.guzzlephp.org/en/latest/request-options.html#timeout