### PR TITLE
adds missing changelog entry

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@
 Unreleased
 ==========
 
+ - Add support for fetch style ``PDO::FETCH_OBJ``.
+
 2017/07/17 0.6.3
 ================
 


### PR DESCRIPTION
adds the changelog entry for the fetch style ``PDO::FETCH_OBJ``
that has been introduced with 19b67ec991e87219194e6b5b0afabbaca23d350e