### PR TITLE
Remove nightly build from travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 
 php:
   - 7.2
-  - nightly
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Not all depended libraries are working with the latest nightly and
supporting the latest nightly is not required.

## Summary of the changes / Why this is an improvement


## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
