### PR TITLE
[travis] Add missing `truststore` to CrateDB docker setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,14 @@ code: &code
   services:
    - docker
   before_script:
-   - docker run --name crate -d -v $PWD/test/provisioning/crate.yml:/crate/config/crate.yml -v $PWD/test/provisioning/keystore:/vagrant/test/provisioning/keystore -p 127.0.0.1:4200:4200 crate:latest
+   - >
+     docker run
+     --name crate -d
+     -v $PWD/test/provisioning/crate.yml:/crate/config/crate.yml
+     -v $PWD/test/provisioning/keystore:/vagrant/test/provisioning/keystore
+     -v $PWD/test/provisioning/truststore:/vagrant/test/provisioning/truststore
+     -p 127.0.0.1:4200:4200
+     crate:latest
    - composer self-update
    - composer install --prefer-source
   script:


### PR DESCRIPTION
The `truststore` path mapping was missing on the docker run command and thus SSL connections to CrateDB didn't work.

Before CrateDB 4.2.x, a custom truststore was generated on node startup and the `ssl.truststore_filepath` setting wasn’t required.

Relates https://github.com/crate/crate/pull/9690.