### PR TITLE
Bump guzzle http client to `~7.0`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Unreleased
 ==========
 
+- Bumped required guzzle http client dependency to ``~7.0``
+
 2019/04/09 1.0.1
 ================
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php":     "^7.2",
         "ext-pdo": "*",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~7.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Relates https://github.com/crate/crate-pdo/issues/108.