### PR TITLE
Improve documentation: Update to crate-docs 2.0.0, fix broken links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,11 +16,15 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+
+      - name: Acquire sources
+        uses: actions/checkout@v2
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.7
+
       - name: Build docs
         run: |
           cd docs && make check

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,8 +18,58 @@
 # pursuant to the terms of the relevant commercial agreement.
 
 
-# Do not edit anything below this line
-###############################################################################
+# =============================================================================
+# Crate Docs
+# =============================================================================
+
+# The Crate Docs project provides a common set of tools for producing the
+# Crate.io documentation. See <https://github.com/crate/crate-docs/> for more
+# information.
+
+# This file is taken from the demo Sphinx project available at
+# <https://github.com/crate/crate-docs/blob/main/docs>. This demo docs project
+# provides a reference implementation that should be copied for all Sphinx
+# projects at Crate.io.
+
+# The Crate Docs build system works by centralizing its core components in the
+# `crate-docs` repository. At build time, this Makefile creates a copy of the
+# this project under the `.crate-docs` directory. This Makefile is an interface
+# for those core components.
+
+
+# Upgraded instructions
+# -----------------------------------------------------------------------------
+
+# You must pin your Sphinx project to a specific version of the Crate Docs
+# project. You can do this by editing the `build.json` file. Change the JSON
+# `message` value to the desired release number. A list of releases is
+# available at <https://github.com/crate/crate-docs/releases>.
+
+# Although care has been taken to restrict changes to the core components, you
+# may occasionally need to update your project to match the reference
+# implementation. Check the release notes for any special instructions.
+
+
+# Project-specific customization
+# =============================================================================
+
+# If you want to customize the build system for your Sphinx project, add lines
+# to this section.
+
+
+# Build system integration
+# =============================================================================
+
+# This is a boilerplate section is required for integration with the Crate Docs
+# build system. All Sphinx projects using a the same Crate Docs version
+# should have exactly the same boilerplate.
+
+# IF YOU ARE EDITING THIS FILE IN A REAL SPHINX PROJECT, YOU SHOULD NOT MAKE
+# ANY CHANGES TO THIS SECTION.
+
+# If you want to make changes to the boilerplate, please make a pull request on
+# the demo Sphinx project in the Crate Docs repository available at
+# <https://github.com/crate/crate-docs/blob/main/docs>.
 
 .EXPORT_ALL_VARIABLES:
 
@@ -27,36 +77,69 @@ DOCS_DIR      := docs
 TOP_DIR       := ..
 BUILD_JSON    := build.json
 BUILD_REPO    := https://github.com/crate/crate-docs.git
+LATEST_BUILD  := https://github.com/crate/crate-docs/releases/latest
 CLONE_DIR     := .crate-docs
-SRC_DIR       := $(CLONE_DIR)/src
-SELF_SRC      := $(TOP_DIR)/src
+SRC_DIR       := $(CLONE_DIR)/common-build
+SELF_SRC      := $(TOP_DIR)/common-build
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk
 SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
 # Parse the JSON file
-BUILD_VERSION = $(shell cat $(BUILD_JSON) | \
+BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
     python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
 
 ifeq ($(BUILD_VERSION),)
-$(error No version specified in $(BUILD_JSON))
+$(error No build version specified in `$(BUILD_JSON)`.)
+endif
+
+# This is a non-essential check so we timeout after only two seconds so as not
+# to frustrate the user when there are network issues
+LATEST_VERSION := $(shell curl -sI --connect-timeout 2 '$(LATEST_BUILD)' | \
+    grep -i 'Location:' | grep -Eoh '[^/]+$$')
+
+# Skip if no version could be determined (i.e., because of a network error)
+ifneq ($(LATEST_VERSION),)
+# Only issue a warning if there is a version mismatch
+ifneq ($(BUILD_VERSION),$(LATEST_VERSION))
+define version_warning
+You are using Crate Docs version $(BUILD_VERSION), however version \
+$(LATEST_VERSION) is available. You should consider upgrading. Follow the \
+instructions in `Makefile` and then run `make reset`.
+endef
+endif
 endif
 
 # Default rule
 .PHONY: help
 help: $(CLONE_DIR)
+	@ $(MAKE) version-warn
 	@ $(SRC_MAKE) $@
+
+.PHONY: version-warn
+version-warn:
+	@ # Because version numbers may vary in length, we must wrap the warning
+	@ # message at run time to be sure of correct output
+	@ if test -n '$(version_warning)'; then \
+	      printf '\033[33m'; \
+	      echo '$(version_warning)' | fold -w 79 -s; \
+	      printf '\033[00m\n'; \
+	  fi
 
 ifneq ($(wildcard $(SELF_MAKEFILE)),)
 # The project detects itself and fakes an install of its own core build rules
 # so that it can test itself
 $(CLONE_DIR):
-	mkdir -p $@
-	cp -R $(SELF_SRC) $(SRC_DIR)
+	@ printf '\033[1mInstalling the build system...\033[00m\n'
+	@ mkdir -p $@
+	@ cp -R $(SELF_SRC) $(SRC_DIR)
+	@ printf 'Created: $(CLONE_DIR)\n'
 else
 # All other projects install a versioned copy of the core build rules
 $(CLONE_DIR):
-	git clone --depth=1 -c advice.detachedHead=false \
+	@ printf '\033[1mInstalling the build system...\033[00m\n'
+	@ git clone --depth=1 -c advice.detachedHead=false \
 	    --branch=$(BUILD_VERSION) $(BUILD_REPO) $(CLONE_DIR)
+	@ printf 'Created: $(CLONE_DIR)\n'
 endif
 
 # Don't pass through this target
@@ -66,8 +149,11 @@ Makefile:
 # By default, pass targets through to the core build rules
 .PHONY:
 %: $(CLONE_DIR)
+	@ $(MAKE) version-warn
 	@ $(SRC_MAKE) $@
 
 .PHONY: reset
 reset:
-	rm -rf $(CLONE_DIR)
+	@ printf '\033[1mResetting the build system...\033[00m\n'
+	@ rm -rf $(CLONE_DIR)
+	@ printf 'Removed: $(CLONE_DIR)\n'

--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -36,12 +36,4 @@ Consult the following table for CrateDB version compatibility notes:
 |                |                 | The default CrateDB user is ``crate`` and |
 |                |                 | no password is set.                       |
 |                |                 |                                           |
-|                |                 | The `enterprise edition`_ of CrateDB      |
-|                |                 | allows you to `create your own users`_.   |
-|                |                 |                                           |
-|                |                 | Prior versions of CrateDB do not support  |
-|                |                 | this feature.                             |
 +----------------+-----------------+-------------------------------------------+
-
-.. _create your own users: https://crate.io/docs/crate/reference/en/latest/admin/user-management.html
-.. _enterprise edition: https://crate.io/products/cratedb-enterprise/

--- a/docs/appendices/data-types.rst
+++ b/docs/appendices/data-types.rst
@@ -66,32 +66,32 @@ CrateDB Type  PDO Type
 ============= ========================
 
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#boolean
-__ https://secure.php.net/manual/en/language.types.boolean.php
+__ https://www.php.net/manual/en/language.types.boolean.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.integer.php
+__ https://www.php.net/manual/en/language.types.integer.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.integer.php
+__ https://www.php.net/manual/en/language.types.integer.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.integer.php
+__ https://www.php.net/manual/en/language.types.integer.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.float.php
+__ https://www.php.net/manual/en/language.types.float.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://secure.php.net/manual/en/language.types.float.php
+__ https://www.php.net/manual/en/language.types.float.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-types
-__ https://secure.php.net/manual/en/language.types.string.php
+__ https://www.php.net/manual/en/language.types.string.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#ip
-__ https://secure.php.net/manual/en/language.types.string.php
+__ https://www.php.net/manual/en/language.types.string.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#date-time-types
-__ https://secure.php.net/manual/en/language.types.integer.php
+__ https://www.php.net/manual/en/language.types.integer.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-point
-__ https://secure.php.net/manual/en/language.types.array.php
+__ https://www.php.net/manual/en/language.types.array.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-shape
-__ https://secure.php.net/manual/en/language.types.object.php
+__ https://www.php.net/manual/en/language.types.object.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#object
-__ https://secure.php.net/manual/en/language.types.object.php
+__ https://www.php.net/manual/en/language.types.object.php
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#array
-__ https://secure.php.net/manual/en/language.types.array.php
+__ https://www.php.net/manual/en/language.types.array.php
 
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#boolean
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
@@ -108,6 +108,6 @@ __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#g
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#object
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#array
 
-.. _bindParam(): http://de2.php.net/manual/en/pdostatement.bindparam.php
-.. _bindValue(): http://de2.php.net/manual/en/pdostatement.bindvalue.php
-.. _parameter class constant: http://de2.php.net/manual/en/pdo.constants.php
+.. _bindParam(): https://www.php.net/manual/en/pdostatement.bindparam.php
+.. _bindValue(): https://www.php.net/manual/en/pdostatement.bindvalue.php
+.. _parameter class constant: https://www.php.net/manual/en/pdo.constants.php

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "main"
+  "message": "2.0.0"
 }

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -239,12 +239,12 @@ setup process.
 .. _database user: https://crate.io/docs/crate/reference/en/latest/admin/user-management.html
 .. _documentation: https://github.com/crate/crate-sample-apps/blob/master/php/documentation.md
 .. _DSN: https://en.wikipedia.org/wiki/Data_source_name
-.. _fetch modes: https://secure.php.net/manual/en/pdostatement.fetch.php
+.. _fetch modes: https://www.php.net/manual/en/pdostatement.fetch.php
 .. _HTTP connection: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html
 .. _HTTP endpoint: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html
 .. _PDO API Documentation: http://www.php.net/pdo
-.. _PDO documentation: http://www.php.net/manual/en/intro.pdo.php
-.. _PDO::setAttribute: http://php.net/manual/en/pdo.setattribute.php
+.. _PDO documentation: https://www.php.net/manual/en/intro.pdo.php
+.. _PDO::setAttribute: https://www.php.net/manual/en/pdo.setattribute.php
 .. _round-robin DNS: https://en.wikipedia.org/wiki/Round-robin_DNS
 .. _sample application: https://github.com/crate/crate-sample-apps/tree/master/php
-.. _setAttribute: https://secure.php.net/manual/en/pdo.setattribute.php
+.. _setAttribute: https://www.php.net/manual/en/pdo.setattribute.php


### PR DESCRIPTION
Hi,

this upgrades the crate-docs build system to version 2.0.0.

With kind regards,
Andreas.