### PR TITLE
fix: composer authoritative

### DIFF
--- a/src/Crate/PDO/PDOImplementation.php
+++ b/src/Crate/PDO/PDOImplementation.php
@@ -42,8 +42,13 @@ use const PHP_VERSION_ID;
 
 // @codeCoverageIgnoreStart
 if (PHP_VERSION_ID >= 80000) {
-    class_alias('\Crate\PDO\PDOImplementationPhp8', '\Crate\PDO\PDOImplementation');
+    trait PDOImplementation {
+        use PDOImplementationPhp8;
+    }
 } else {
-    class_alias('\Crate\PDO\PDOImplementationPhp7', '\Crate\PDO\PDOImplementation');
+    trait PDOImplementation {
+        use PDOImplementationPhp7;
+    }
 }
+
 // @codeCoverageIgnoreEnd

--- a/src/Crate/PDO/PDOImplementation.php
+++ b/src/Crate/PDO/PDOImplementation.php
@@ -42,11 +42,13 @@ use const PHP_VERSION_ID;
 
 // @codeCoverageIgnoreStart
 if (PHP_VERSION_ID >= 80000) {
-    trait PDOImplementation {
+    trait PDOImplementation
+    {
         use PDOImplementationPhp8;
     }
 } else {
-    trait PDOImplementation {
+    trait PDOImplementation
+    {
         use PDOImplementationPhp7;
     }
 }

--- a/src/Crate/PDO/PDOImplementation.php
+++ b/src/Crate/PDO/PDOImplementation.php
@@ -47,6 +47,7 @@ if (PHP_VERSION_ID >= 80000) {
         use PDOImplementationPhp8;
     }
 } else {
+    // phpcs:disable
     trait PDOImplementation
     {
         use PDOImplementationPhp7;

--- a/src/Crate/PDO/PDOInterface.php
+++ b/src/Crate/PDO/PDOInterface.php
@@ -53,6 +53,7 @@ if (PHP_VERSION_ID >= 80000) {
     {
     }
 } else {
+    // phpcs:disable
     interface PDOInterface extends PDOInterfacePhp7
     {
     }

--- a/src/Crate/PDO/PDOInterface.php
+++ b/src/Crate/PDO/PDOInterface.php
@@ -49,8 +49,8 @@ use const PHP_VERSION_ID;
  */
 // @codeCoverageIgnoreStart
 if (PHP_VERSION_ID >= 80000) {
-    class_alias('\Crate\PDO\PDOInterfacePhp8', '\Crate\PDO\PDOInterface');
+    interface PDOInterface extends PDOInterfacePhp8 {}
 } else {
-    class_alias('\Crate\PDO\PDOInterfacePhp7', '\Crate\PDO\PDOInterface');
+    interface PDOInterface extends PDOInterfacePhp7 {}
 }
 // @codeCoverageIgnoreEnd

--- a/src/Crate/PDO/PDOInterface.php
+++ b/src/Crate/PDO/PDOInterface.php
@@ -49,8 +49,12 @@ use const PHP_VERSION_ID;
  */
 // @codeCoverageIgnoreStart
 if (PHP_VERSION_ID >= 80000) {
-    interface PDOInterface extends PDOInterfacePhp8 {}
+    interface PDOInterface extends PDOInterfacePhp8
+    {
+    }
 } else {
-    interface PDOInterface extends PDOInterfacePhp7 {}
+    interface PDOInterface extends PDOInterfacePhp7
+    {
+    }
 }
 // @codeCoverageIgnoreEnd

--- a/src/Crate/PDO/PDOStatementImplementation.php
+++ b/src/Crate/PDO/PDOStatementImplementation.php
@@ -41,12 +41,13 @@ namespace Crate\PDO;
 use const PHP_VERSION_ID;
 
 if (PHP_VERSION_ID >= 80000) {
-    trait PDOStatementImplementation {
+    trait PDOStatementImplementation
+    {
         use PDOStatementImplementationPhp8;
     }
 } else {
-    trait PDOStatementImplementation {
+    trait PDOStatementImplementation
+    {
         use PDOStatementImplementationPhp7;
     }
 }
-

--- a/src/Crate/PDO/PDOStatementImplementation.php
+++ b/src/Crate/PDO/PDOStatementImplementation.php
@@ -41,7 +41,12 @@ namespace Crate\PDO;
 use const PHP_VERSION_ID;
 
 if (PHP_VERSION_ID >= 80000) {
-    class_alias('\Crate\PDO\PDOStatementImplementationPhp8', '\Crate\PDO\PDOStatementImplementation');
+    trait PDOStatementImplementation {
+        use PDOStatementImplementationPhp8;
+    }
 } else {
-    class_alias('\Crate\PDO\PDOStatementImplementationPhp7', '\Crate\PDO\PDOStatementImplementation');
+    trait PDOStatementImplementation {
+        use PDOStatementImplementationPhp7;
+    }
 }
+

--- a/src/Crate/PDO/PDOStatementImplementation.php
+++ b/src/Crate/PDO/PDOStatementImplementation.php
@@ -46,6 +46,7 @@ if (PHP_VERSION_ID >= 80000) {
         use PDOStatementImplementationPhp8;
     }
 } else {
+    // phpcs:disable
     trait PDOStatementImplementation
     {
         use PDOStatementImplementationPhp7;


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
* make it possible to use composer [authoritative classmap](https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-a-authoritative-class-maps)
* extending a class based on php version is calculated at dump-autoload


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
