### PR TITLE
Documentation: Fix dependencies for version 1.x

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,1 @@
-# don't pin crate version numbers so the latest will always be pulled when you
-# set up your environment from scratch
-
 crate-docs-theme
-
-# packages for local dev
-
-sphinx-autobuild==0.6.0
-
-# the next section should mirror the RTD environment
-
-alabaster>=0.7,<0.8,!=0.7.5
-setuptools<41
-sphinx==1.7.4


### PR DESCRIPTION
The documentation for CrateDB PDO version 1.x still uses an older theme. It maybe is related to the version pinning of Sphinx, which will probably make `pip` select an older version of `crate-docs-theme`.

-- https://crate.io/docs/pdo/en/1.0/
