### PR TITLE
CI: Add support for PHP8.1 and PHP8.2, and update GHA recipe versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,21 @@
 name: Docs
 
 on:
-  workflow_dispatch:
-  pull_request: ~
   push:
-    branches:
-      - main
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
   schedule:
     - cron: '0 7 * * *'
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   documentation:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
 
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.10"
 
       - name: Build docs
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '7.3', '7.4', '8.0', '8.1' ]
+        php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
 
     name: PHP ${{ matrix.php-version }} on OS ${{ matrix.os }}
     steps:
@@ -55,13 +55,13 @@ jobs:
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@v3
-        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1')
+        if: always() && (matrix.php-version == '7.4' || startsWith(matrix.php-version, '8.'))
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true
 
       - name: Upload coverage results to Scrutinizer CI
-        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1')
+        if: always() && (matrix.php-version == '7.4' || startsWith(matrix.php-version, '8.'))
         run: |
           echo "Git HEAD ref:"
           git log --pretty=%P -n1 HEAD

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
 
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -36,7 +36,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: composer, phpunit:^9.5
 
-      - uses: ramsey/composer-install@v1
+      - uses: ramsey/composer-install@v2
 
       - name: Run code style checks
         run: composer run check-style
@@ -46,7 +46,7 @@ jobs:
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0')
         with:
           files: ./build/logs/clover.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [ main ]
 
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   tests:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04' ] #, macos-latest, windows-latest ]
+        os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
         php-version: [ '7.3', '7.4', '8.0' ]
 
     name: PHP ${{ matrix.php-version }} on OS ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '7.3', '7.4', '8.0' ]
+        php-version: [ '7.3', '7.4', '8.0', '8.1' ]
 
     name: PHP ${{ matrix.php-version }} on OS ${{ matrix.os }}
     steps:
@@ -55,13 +55,13 @@ jobs:
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@v3
-        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0')
+        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1')
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true
 
       - name: Upload coverage results to Scrutinizer CI
-        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0')
+        if: always() && (matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1')
         run: |
           echo "Git HEAD ref:"
           git log --pretty=%P -n1 HEAD

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -30,7 +30,7 @@ build:
     analysis:
       environment:
         php:
-          version: 8.0
+          version: 8.1
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog for crate-pdo
 Unreleased
 ==========
 
+- Added support for PHP 8.1
+
 2021/07/29 2.1.3
 ================
 - Make it possible to use Composer authoritative classmap. Thanks, @JulianMar!

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog for crate-pdo
 Unreleased
 ==========
 
-- Added support for PHP 8.1
+- Added support for PHP 8.1 and PHP 8.2
 
 2021/07/29 2.1.3
 ================

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB PDO Adapter
     :target: https://packagist.org/packages/crate/crate-pdo
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-7.3%2C%207.4%2C%208.0-green.svg
+.. image:: https://img.shields.io/badge/PHP-7.3%2C%207.4%2C%208.0%2C%208.1-green.svg
     :target: https://packagist.org/packages/crate/crate-pdo
     :alt: Supported PHP versions
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB PDO Adapter
     :target: https://packagist.org/packages/crate/crate-pdo
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-7.3%2C%207.4%2C%208.0%2C%208.1-green.svg
+.. image:: https://img.shields.io/badge/PHP-7.3%2C%207.4%2C%208.0%2C%208.1%2C%208.2-green.svg
     :target: https://packagist.org/packages/crate/crate-pdo
     :alt: Supported PHP versions
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/crate/crate-pdo",
     "keywords": ["database", "pdo", "cratedb"],
     "require": {
-        "php":     "^7.3|^8.0",
+        "php":     "^7.3|^8.0|^8.1",
         "ext-pdo": "*",
         "guzzlehttp/guzzle": "^7.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/crate/crate-pdo",
     "keywords": ["database", "pdo", "cratedb"],
     "require": {
-        "php":     "^7.3|^8.0|^8.1",
+        "php":     "^7.3|^8.0|^8.1|^8.2",
         "ext-pdo": "*",
         "guzzlehttp/guzzle": "^7.2"
     },


### PR DESCRIPTION
Hi there,

mainly intended to add support for PHP8.1 and PHP8.2, there are also a few other maintenance commits. See also https://github.com/crate/crate-dbal/pull/121.

- https://php.watch/versions/8.1
- https://php.watch/versions/8.2

With kind regards,
Andreas.