### PR TITLE
Add support for PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '7.3', '7.4', '8.0', '8.1' ]
+        php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
 
     name: PHP ${{ matrix.php-version }} on OS ${{ matrix.os }}
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog for crate-pdo
 Unreleased
 ==========
 
-- Added support for PHP 8.1
+- Added support for PHP 8.1 and PHP 8.2
 
 2021/07/29 2.1.3
 ================

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB PDO Adapter
     :target: https://packagist.org/packages/crate/crate-pdo
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-7.3%2C%207.4%2C%208.0%2C%208.1-green.svg
+.. image:: https://img.shields.io/badge/PHP-7.3%2C%207.4%2C%208.0%2C%208.1%2C%208.2-green.svg
     :target: https://packagist.org/packages/crate/crate-pdo
     :alt: Supported PHP versions
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/crate/crate-pdo",
     "keywords": ["database", "pdo", "cratedb"],
     "require": {
-        "php":     "^7.3|^8.0|^8.1",
+        "php":     "^7.3|^8.0|^8.1|^8.2",
         "ext-pdo": "*",
         "guzzlehttp/guzzle": "^7.2"
     },


### PR DESCRIPTION
Following up on #132, this patch adds support for PHP8.2.

https://php.watch/versions/8.2
