### PR TITLE
Release 2.1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,14 @@ Changelog for crate-pdo
 Unreleased
 ==========
 
+2022/11/29 2.1.4
+================
+
 - Added support for PHP 8.1 and PHP 8.2
 
 2021/07/29 2.1.3
 ================
+
 - Make it possible to use Composer authoritative classmap. Thanks, @JulianMar!
 
 2021/04/28 2.1.2

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -35,7 +35,7 @@ class PDO extends BasePDO implements PDOInterface
 {
     use PDOImplementation;
 
-    public const VERSION     = '2.1.3';
+    public const VERSION     = '2.1.4';
     public const DRIVER_NAME = 'crate';
 
     public const DSN_REGEX = '/^(?:crate:)(?:((?:[\w\.-]+:\d+\,?)+))\/?([\w]+)?$/';


### PR DESCRIPTION
Publishing a patch release which allows installation on PHP8.1 and PHP8.2. See also https://github.com/crate/crate-dbal/pull/123.