### PR TITLE
Documentation: Satisfy link checker on CI/GHA

### DIFF
--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -242,7 +242,7 @@ setup process.
 .. _fetch modes: https://www.php.net/manual/en/pdostatement.fetch.php
 .. _HTTP connection: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html
 .. _HTTP endpoint: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html
-.. _PDO API Documentation: http://www.php.net/pdo
+.. _PDO API Documentation: https://www.php.net/pdo
 .. _PDO documentation: https://www.php.net/manual/en/intro.pdo.php
 .. _PDO::setAttribute: https://www.php.net/manual/en/pdo.setattribute.php
 .. _round-robin DNS: https://en.wikipedia.org/wiki/Round-robin_DNS

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,6 @@ interface for accessing databases in PHP.
 .. _CrateDB: https://crate.io/products/cratedb/
 .. _documentation: https://github.com/crate/crate-sample-apps/blob/master/php/documentation.md
 .. _hosted on GitHub: https://github.com/crate/crate-pdo
-.. _PDO documentation: http://www.php.net/manual/en/intro.pdo.php
-.. _PDO: http://www.php.net/manual/en/intro.pdo.php
+.. _PDO documentation: https://www.php.net/manual/en/intro.pdo.php
+.. _PDO: https://www.php.net/manual/en/intro.pdo.php
 .. _sample application: https://github.com/crate/crate-sample-apps/tree/master/php


### PR DESCRIPTION
The documentation link checker started croaking on non-https URLs to php.net, apparently only on CI.
