### PR TITLE
mergify: Remove deprecated rebase_fallback option

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,4 +20,3 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
The configuration uses the deprecated rebase_fallback attribute of the queue action.
Confirmed in https://github.com/crate/crate/pull/13484

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
