### PR TITLE
Add support for CrateDB bulk operations for improved DML efficiency

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,16 @@
+---
 version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
 
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
-
-python:
-  version: 3.7
-  install:
-    - requirements: docs/requirements.txt

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog for crate-pdo
 Unreleased
 ==========
 
+- Added support for `CrateDB bulk operations`_, for improved efficiency on
+  DML operations.
+
+.. _CrateDB bulk operations: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
+
 2022/11/29 2.1.4
 ================
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -48,6 +48,14 @@ If the environment is outdated, you can upgrade it::
 
     composer update
 
+If you see messages like ``Warning: No code coverage driver available`` when running
+the tests, you will need to install the ``xdebug`` extension::
+
+    pecl install xdebug
+
+It may happen that you will have to re-install it, for example after your PHP
+version has been upgraded by your package manager.
+
 
 Running the Tests
 =================
@@ -60,14 +68,24 @@ You can run the tests like::
     # Run test suite
     composer run test
 
-    # Run code style checks
-    composer run style
-
     # Output coverage report as HTML
     composer run -- test --coverage-html ./report
+    open report/index.html
 
     # Run specific tests
     composer run -- test --filter "testFetchColumn"
+
+
+Invoke code style checks
+========================
+
+::
+
+    # Run code style checks
+    composer run check-style
+
+    # Some code style quirks can be automatically fixed
+    composer run fix-style
 
 
 
@@ -119,19 +137,6 @@ Running the Tests
     # Run tests on both PHP7 and PHP8 to get the full picture of coverage
     composer run multicover
     open build/multicover/html/index.html
-
-
-Invoke code style checks
-========================
-
-::
-
-    # Run code style checks
-    composer run check-style
-
-    # Some code style quirks can be automatically fixed
-    composer run fix-style
-
 
 
 ****************************

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -221,6 +221,40 @@ method used.
 |                            | ``PDO::FETCH_OBJ``    |
 +----------------------------+-----------------------+
 
+Bulk operations
+===============
+
+With CrateDB :ref:`crate-reference:http-bulk-ops`, suitable for ``INSERT``,
+``UPDATE``, and ``DELETE`` statements, you can submit multiple records, aka.
+batches, to CrateDB within a single operation. By using this way of communication,
+both the client and the server will not waste resources on building and decoding
+huge SQL statements, and data will also propagate more efficiently between CrateDB
+cluster nodes.
+
+To use this mode, the ``PDOStatement`` offers a corresponding ``bulkMode`` option.
+When creating a statement instance with it, the ``$parameters`` data will be
+obtained as a **list of records**, like demonstrated in the example below.
+
+Please note that you **must** use ``PDO::FETCH_NUM`` on the fetch operation,
+because the response object type ``BulkResponse`` is different than the regular
+response type ``Collection``.
+
+.. code-block:: php
+
+    // Run insert operation.
+    $parameters = [[5, 'foo', 1], [6, 'bar', 2], [7, 'foo', 3], [8, 'bar', 4]];
+    $statement = $connection->prepare(
+        'INSERT INTO test_table (id, name, int_type) VALUES (?, ?, ?)',
+        array("bulkMode" => true));
+    $statement->execute($parameters);
+
+    // Evaluate response.
+    // MUST use `PDO::FETCH_NUM` for returning bulk operation responses.
+    print("Total count: {$statement->rowCount()}\n");
+    $response = $statement->fetchAll(PDO::FETCH_NUM);
+    print_r($response);
+
+
 Next steps
 ==========
 

--- a/src/Crate/PDO/Http/ServerInterface.php
+++ b/src/Crate/PDO/Http/ServerInterface.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace Crate\PDO\Http;
 
 use Crate\PDO\PDOInterface;
+use Crate\Stdlib\BulkResponseInterface;
 use Crate\Stdlib\CollectionInterface;
 
 interface ServerInterface
@@ -49,7 +50,22 @@ interface ServerInterface
      *
      * @return CollectionInterface
      */
-    public function execute(string $queryString, array $parameters): CollectionInterface;
+    public function execute(string $queryString, array $parameters): ?CollectionInterface;
+
+    /**
+     * Execute the PDOStatement in "bulk operations" and return the response from server
+     * wrapped inside a BulkResponseInterface.
+     *
+     * Bulk operations are only supported for `INSERT`, `UPDATE`, and `DELETE` statements.
+     *
+     * https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
+     *
+     * @param string $queryString
+     * @param array  $parameters
+     *
+     * @return BulkResponseInterface
+     */
+    public function executeBulk(string $queryString, array $parameters): ?BulkResponseInterface;
 
     /**
      * @return array

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -74,6 +74,7 @@ class PDO extends BasePDO implements PDOInterface
         'timeout'          => 0.0,
         'auth'             => [],
         'defaultSchema'    => 'doc',
+        'bulkMode'         => false,
     ];
 
     /**
@@ -125,7 +126,11 @@ class PDO extends BasePDO implements PDOInterface
             $this->lastStatement = $statement;
 
             try {
-                return $this->server->execute($sql, $parameters);
+                if ($statement->isBulkMode()) {
+                    return $this->server->executeBulk($sql, $parameters);
+                } else {
+                    return $this->server->execute($sql, $parameters);
+                }
             } catch (Exception\RuntimeException $e) {
                 if ($this->getAttribute(self::ATTR_ERRMODE) === self::ERRMODE_EXCEPTION) {
                     throw new Exception\PDOException($e->getMessage(), $e->getCode());

--- a/src/Crate/Stdlib/BulkResponse.php
+++ b/src/Crate/Stdlib/BulkResponse.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Licensed to CRATE Technology GmbH("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+declare(strict_types=1);
+
+namespace Crate\Stdlib;
+
+final class BulkResponse implements BulkResponseInterface
+{
+    /**
+     * Result object for CrateDB bulk operations.
+     * https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
+     * @var array
+     */
+    private $results;
+
+    /**
+     * @var string[]
+     */
+    private $columnsAsKeys;
+
+    /**
+     * @var string[]
+     */
+    private $columnsAsValues;
+
+    /**
+     * @var int
+     */
+    private $duration;
+
+    /**
+     * @param array    $results
+     * @param string[] $columns
+     * @param float    $duration
+     */
+    public function __construct(array $results, array $columns, float $duration)
+    {
+        $this->results         = $results;
+        $this->columnsAsKeys   = array_flip($columns);
+        $this->columnsAsValues = $columns;
+        $this->duration        = $duration;
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function map(callable $callback): array
+    {
+        return array_map($callback, $this->results);
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function getColumnIndex($column)
+    {
+        if (isset($this->columnsAsKeys[$column])) {
+            return $this->columnsAsKeys[$column];
+        }
+
+        return null;
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function getColumns($columnsAsKeys = true): array
+    {
+        return $columnsAsKeys ? $this->columnsAsKeys : $this->columnsAsValues;
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function getRows(): array
+    {
+        return $this->getResults();
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function current(): array
+    {
+        return current($this->results);
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function next(): void
+    {
+        next($this->results);
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function key()
+    {
+        return key($this->results);
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function valid(): bool
+    {
+        return $this->key() !== null;
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function rewind(): void
+    {
+        reset($this->results);
+    }
+
+    /**
+     * {@Inheritdoc}
+     */
+    public function count(): int
+    {
+        $count = 0;
+        foreach ($this->results as $element) {
+            $count += $element["rowcount"];
+        }
+        return $count;
+    }
+}

--- a/src/Crate/Stdlib/BulkResponseInterface.php
+++ b/src/Crate/Stdlib/BulkResponseInterface.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Licensed to CRATE Technology GmbH("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+declare(strict_types=1);
+
+namespace Crate\Stdlib;
+
+use Countable;
+use Iterator;
+
+interface BulkResponseInterface extends Countable, Iterator
+{
+    /**
+     * Get the columns as either an array where the keys point to the index or vice versa
+     *
+     * @param bool $columnsAsKeys
+     *
+     * @return string[]
+     */
+    public function getColumns($columnsAsKeys = true);
+
+    /**
+     * Get the column index
+     *
+     * @param string $column
+     *
+     * @return string|null
+     */
+    public function getColumnIndex($column);
+
+    /**
+     * Apply a callback to each item in the collection
+     *
+     * @param callable $callable
+     *
+     * @return array
+     */
+    public function map(callable $callable);
+
+    /**
+     * Get all the bulk-operations results
+     *
+     * @return array
+     */
+    public function getResults();
+
+    /**
+     * Be compatible with the `Collection` interface.
+     * Otherwise, it would not fit well into the `->fetch()` methods.
+     *
+     * @return array
+     */
+    public function getRows();
+}

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -31,6 +31,7 @@ use Crate\PDO\PDOStatement;
 use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * Tests for {@see \Crate\PDO\PDO}
@@ -354,4 +355,25 @@ class PDOTest extends TestCase
             [PDO::FETCH_NAMED],
         ];
     }
+
+    /**
+     * Verify support for CrateDB bulk operations.
+     * https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
+     *
+     * @covers ::query
+     */
+    public function testBulkMode()
+    {
+        $statement = $this->pdo->prepare("INSERT INTO foobar;", array("bulkMode" => true));
+
+        // Enable accessing the private `options` property of the `PDOStatement` instance.
+        $class = new ReflectionClass($statement);
+        $options_p = $class->getProperty("options");
+        $options_p->setAccessible(true);
+        $options = $options_p->getValue($statement);
+
+        // Verify bulk mode has been enabled.
+        $this->assertEquals(true, $options["bulkMode"]);
+    }
+
 }

--- a/test/CrateTest/Stdlib/BulkResponseTest.php
+++ b/test/CrateTest/Stdlib/BulkResponseTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace CrateTest\Stdlib;
+
+use Crate\Stdlib\BulkResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class BulkResponseTest
+ *
+ * @coversDefaultClass \Crate\Stdlib\BulkResponse
+ * @covers ::<!public>
+ *
+ * @group unit
+ */
+class BulkResponseTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $results = [
+        ["rowcount" => 1],
+        ["rowcount" => 1],
+    ];
+
+    /**
+     * @var array
+     */
+    private $columns = ['id', 'name'];
+
+    /**
+     * @var BulkResponse
+     */
+    private $response;
+
+    /**
+     * @covers ::__construct
+     */
+    protected function setUp(): void
+    {
+        $this->response = new BulkResponse($this->results, $this->columns, 0);
+    }
+
+    /**
+     * @covers ::map
+     */
+    public function testMap()
+    {
+        $result = $this->response->map(function(array $row) {
+            return implode(':', $row);
+        });
+
+        $this->assertEquals([1, 1], $result);
+    }
+
+    /**
+     * @covers ::getColumnIndex
+     */
+    public function testGetColumnIndex()
+    {
+        $this->assertNull($this->response->getColumnIndex('helloWorld'));
+
+        $this->assertEquals(0, $this->response->getColumnIndex('id'));
+        $this->assertEquals(1, $this->response->getColumnIndex('name'));
+    }
+
+    /**
+     * @covers ::getColumns
+     */
+    public function testGetColumns()
+    {
+        $this->assertEquals(['id' => 0, 'name' => 1], $this->response->getColumns());
+        $this->assertEquals(['id', 'name'], $this->response->getColumns(false));
+    }
+
+    /**
+     * @covers ::getColumns
+     */
+    public function testGetColumnsSameColumnTwice() {
+        $this->response = new BulkResponse([], ['id', 'id'], 0);
+        $this->assertEquals(['id' => 0, 'id' => 1], $this->response->getColumns());
+    }
+
+    /**
+     * @covers ::getRows
+     */
+    public function testGetRows()
+    {
+        $this->assertEquals($this->results, $this->response->getRows());
+    }
+
+    /**
+     * @covers ::count
+     */
+    public function testCount()
+    {
+        $this->assertEquals(count($this->results), $this->response->count());
+    }
+
+    public function testIterator()
+    {
+        $this->assertInstanceOf('Iterator', $this->response);
+
+        foreach ($this->response as $index => $row) {
+            $this->assertEquals($this->results[$index], $row);
+        }
+    }
+}


### PR DESCRIPTION
### About
At GH-139, we discovered the driver does not utilize the [CrateDB HTTP bulk operations interface](https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations) yet. This patch aims to address this shortcoming, by adding a proprietary code path, similar to what the Python driver does, and similarly easy to use.

### Documentation
https://crate-pdo--143.org.readthedocs.build/en/143/connect.html#bulk-operations

/cc @hlcianfagna, @mkleen, @hammerhead, @proddata, @seut, @matriv 