### PR TITLE
Maintenance: Towards PHP8, by adding more type hints. Align `PDO::errorCode()` with specification.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,13 @@ Unreleased
 
 - Maintenance: Added more type hints, mitigating lots of deprecation warnings.
 
+Breaking changes
+----------------
+
+- Aligned ``PDO::errorCode()`` with specification, to return error code as
+  string type. See also https://www.php.net/manual/en/pdo.errorcode.php.
+  The signature is ``public PDO::errorCode(): ?string``.
+
 .. _CrateDB bulk operations: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
 
 2022/11/29 2.1.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
   ``Crate\PDO\PDO`` without alias into the main namespace collides with
   PHP's native ``PDO`` class.
 
+- Maintenance: Added more type hints, mitigating lots of deprecation warnings.
+
 .. _CrateDB bulk operations: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
 
 2022/11/29 2.1.4

--- a/examples/insert_basic.php
+++ b/examples/insert_basic.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 
 include("./vendor/autoload.php");
 
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL);
 
 // Connect to CrateDB.
 use Crate\PDO\PDOCrateDB;

--- a/examples/insert_bulk.php
+++ b/examples/insert_bulk.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 include("./vendor/autoload.php");
 
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL);
 
 // Connect to CrateDB.
 use Crate\PDO\PDOCrateDB;

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -30,7 +30,6 @@ use Crate\PDO\Http\ServerInterface;
 use Crate\PDO\Http\ServerPool;
 use Crate\Stdlib\ArrayUtils;
 use PDO as BasePDO;
-use ReturnTypeWillChange;
 
 use const PHP_VERSION_ID;
 
@@ -207,7 +206,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function prepare(string $statement, array $options = [])
     {
         $options = ArrayUtils::toArray($options);
@@ -454,7 +453,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function quote(string $string, int $parameter_type = self::PARAM_STR)
     {
         switch ($parameter_type) {

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -257,7 +257,8 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function exec($statement): int
+    #[\ReturnTypeWillChange]
+    public function exec($statement)
     {
         $statement = $this->prepare($statement);
         $result    = $statement->execute();
@@ -306,7 +307,8 @@ class PDO extends BasePDO implements PDOInterface
      * @throws \Crate\PDO\Exception\PDOException
      * @throws \Crate\PDO\Exception\InvalidArgumentException
      */
-    public function setAttribute(int $attribute, $value): bool
+    #[\ReturnTypeWillChange]
+    public function setAttribute($attribute, $value)
     {
         switch ($attribute) {
             case self::ATTR_DEFAULT_FETCH_MODE:
@@ -382,7 +384,7 @@ class PDO extends BasePDO implements PDOInterface
      * @throws \Crate\PDO\Exception\PDOException
      */
     #[\ReturnTypeWillChange]
-    public function getAttribute(int $attribute)
+    public function getAttribute($attribute)
     {
         switch ($attribute) {
             case self::ATTR_PREFETCH:

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -30,6 +30,7 @@ use Crate\PDO\Http\ServerInterface;
 use Crate\PDO\Http\ServerPool;
 use Crate\Stdlib\ArrayUtils;
 use PDO as BasePDO;
+use ReturnTypeWillChange;
 
 use const PHP_VERSION_ID;
 
@@ -206,7 +207,8 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function prepare($statement, $options = null)
+    #[ReturnTypeWillChange]
+    public function prepare(string $statement, array $options = [])
     {
         $options = ArrayUtils::toArray($options);
 
@@ -224,7 +226,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         return true;
     }
@@ -232,7 +234,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function commit()
+    public function commit(): bool
     {
         return true;
     }
@@ -240,7 +242,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         throw new Exception\UnsupportedException;
     }
@@ -248,7 +250,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function inTransaction()
+    public function inTransaction(): bool
     {
         return false;
     }
@@ -256,7 +258,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function exec($statement)
+    public function exec($statement): int
     {
         $statement = $this->prepare($statement);
         $result    = $statement->execute();
@@ -278,7 +280,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function lastInsertId($name = null)
+    public function lastInsertId(?string $name = null): string
     {
         throw new Exception\UnsupportedException;
     }
@@ -305,7 +307,7 @@ class PDO extends BasePDO implements PDOInterface
      * @throws \Crate\PDO\Exception\PDOException
      * @throws \Crate\PDO\Exception\InvalidArgumentException
      */
-    public function setAttribute($attribute, $value)
+    public function setAttribute(int $attribute, $value): bool
     {
         switch ($attribute) {
             case self::ATTR_DEFAULT_FETCH_MODE:
@@ -372,6 +374,7 @@ class PDO extends BasePDO implements PDOInterface
 
         // A setting changed so we need to reconfigure the server pool
         $this->server->configure($this);
+        return true;
     }
 
     /**
@@ -379,13 +382,12 @@ class PDO extends BasePDO implements PDOInterface
      *
      * @throws \Crate\PDO\Exception\PDOException
      */
-    public function getAttribute($attribute)
+    #[\ReturnTypeWillChange]
+    public function getAttribute(int $attribute)
     {
         switch ($attribute) {
-            case self::ATTR_PERSISTENT:
-                return false;
-
             case self::ATTR_PREFETCH:
+            case self::ATTR_PERSISTENT:
                 return false;
 
             case self::ATTR_CLIENT_VERSION:
@@ -452,7 +454,8 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function quote($string, $parameter_type = self::PARAM_STR)
+    #[ReturnTypeWillChange]
+    public function quote(string $string, int $parameter_type = self::PARAM_STR)
     {
         switch ($parameter_type) {
             case self::PARAM_INT:
@@ -478,17 +481,17 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public static function getAvailableDrivers()
+    public static function getAvailableDrivers(): array
     {
         return array_merge(parent::getAvailableDrivers(), [static::DRIVER_NAME]);
     }
 
-    public function getServerVersion()
+    public function getServerVersion(): string
     {
         return $this->server->getServerVersion();
     }
 
-    public function getServerInfo()
+    public function getServerInfo(): string
     {
         return $this->getServerVersion();
     }

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -288,7 +288,7 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function errorCode()
+    public function errorCode(): ?string
     {
         return $this->lastStatement === null ? null : $this->lastStatement->errorCode();
     }
@@ -296,9 +296,9 @@ class PDO extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function errorInfo()
+    public function errorInfo(): array
     {
-        return $this->lastStatement === null ? null : $this->lastStatement->errorInfo();
+        return $this->lastStatement === null ? ["00000", null, null] : $this->lastStatement->errorInfo();
     }
 
     /**

--- a/src/Crate/PDO/PDOInterfacePhp7.php
+++ b/src/Crate/PDO/PDOInterfacePhp7.php
@@ -36,8 +36,8 @@ interface PDOInterfacePhp7
     public function lastInsertId(?string $name = null): string;
     public function errorCode();
     public function errorInfo();
-    public function setAttribute(int $attribute, $value): bool;
-    public function getAttribute(int $attribute);
+    public function setAttribute($attribute, $value);
+    public function getAttribute($attribute);
     public function getServerVersion();
     public function getServerInfo();
     public static function getAvailableDrivers();

--- a/src/Crate/PDO/PDOInterfacePhp7.php
+++ b/src/Crate/PDO/PDOInterfacePhp7.php
@@ -36,8 +36,8 @@ interface PDOInterfacePhp7
     public function lastInsertId($name = null);
     public function errorCode();
     public function errorInfo();
-    public function setAttribute($attribute, $value);
-    public function getAttribute($attribute);
+    public function setAttribute(int $attribute, $value): bool;
+    public function getAttribute(int $attribute);
     public function getServerVersion();
     public function getServerInfo();
     public static function getAvailableDrivers();

--- a/src/Crate/PDO/PDOInterfacePhp7.php
+++ b/src/Crate/PDO/PDOInterfacePhp7.php
@@ -26,14 +26,14 @@ namespace Crate\PDO;
 
 interface PDOInterfacePhp7
 {
-    public function prepare($statement, $options = null);
+    public function prepare(string $statement, array $options = []);
     public function beginTransaction();
     public function commit();
     public function rollback();
     public function inTransaction();
     public function exec($statement);
     public function doQuery($statement);
-    public function lastInsertId($name = null);
+    public function lastInsertId(?string $name = null): string;
     public function errorCode();
     public function errorInfo();
     public function setAttribute(int $attribute, $value): bool;

--- a/src/Crate/PDO/PDOInterfacePhp8.php
+++ b/src/Crate/PDO/PDOInterfacePhp8.php
@@ -26,18 +26,18 @@ namespace Crate\PDO;
 
 interface PDOInterfacePhp8
 {
-    public function prepare($statement, $options = null);
-    public function beginTransaction();
-    public function commit();
-    public function rollback();
-    public function inTransaction();
+    public function prepare(string $statement, array $options = []);
+    public function beginTransaction(): bool;
+    public function commit(): bool;
+    public function rollback(): bool;
+    public function inTransaction(): bool;
     public function exec($statement);
     public function query(?string $query = null, ?int $fetchMode = null, mixed ...$fetchModeArgs);
-    public function lastInsertId($name = null);
+    public function lastInsertId(?string $name = null): string;
     public function errorCode();
     public function errorInfo();
-    public function setAttribute($attribute, $value);
-    public function getAttribute($attribute);
+    public function setAttribute(int $attribute, $value): bool;
+    public function getAttribute(int $attribute);
     public function getServerVersion();
     public function getServerInfo();
     public static function getAvailableDrivers();

--- a/src/Crate/PDO/PDOInterfacePhp8.php
+++ b/src/Crate/PDO/PDOInterfacePhp8.php
@@ -36,8 +36,8 @@ interface PDOInterfacePhp8
     public function lastInsertId(?string $name = null): string;
     public function errorCode();
     public function errorInfo();
-    public function setAttribute(int $attribute, $value): bool;
-    public function getAttribute(int $attribute);
+    public function setAttribute($attribute, $value);
+    public function getAttribute($attribute);
     public function getServerVersion();
     public function getServerInfo();
     public static function getAvailableDrivers();

--- a/src/Crate/PDO/PDOStatement.php
+++ b/src/Crate/PDO/PDOStatement.php
@@ -373,7 +373,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
      * {@inheritDoc}
      */
     #[\ReturnTypeWillChange]
-    public function fetchColumn(int $column_number = 0)
+    public function fetchColumn($column_number = 0)
     {
         if (!is_int($column_number)) {
             throw new Exception\InvalidArgumentException('column_number must be a valid integer');
@@ -495,7 +495,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      *
-     * @return array|null
+     * @return array
      */
     #[\ReturnTypeWillChange]
     public function errorInfo()
@@ -523,8 +523,12 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
 
     /**
      * {@inheritDoc}
+     *
+     * @param int $attribute
+     * @param mixed $value
      */
-    public function setAttribute(int $attribute, $value): bool
+    #[\ReturnTypeWillChange]
+    public function setAttribute($attribute, $value)
     {
         throw new Exception\UnsupportedException('This driver doesn\'t support setting attributes');
     }
@@ -533,7 +537,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
      * {@inheritDoc}
      */
     #[\ReturnTypeWillChange]
-    public function getAttribute(int $attribute)
+    public function getAttribute($attribute)
     {
         throw new Exception\UnsupportedException('This driver doesn\'t support getting attributes');
     }
@@ -554,7 +558,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
      * {@inheritDoc}
      */
     #[\ReturnTypeWillChange]
-    public function getColumnMeta(int $column)
+    public function getColumnMeta($column)
     {
         throw new Exception\UnsupportedException;
     }

--- a/src/Crate/PDO/PDOStatement.php
+++ b/src/Crate/PDO/PDOStatement.php
@@ -346,6 +346,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
      * {@inheritDoc}
      */
     public function bindValue($parameter, $value, int $data_type = PDO::PARAM_STR): bool
+    #[\ReturnTypeWillChange]
     {
         $value = $this->typedValue($value, $data_type);
         $this->bindParam($parameter, $value, $data_type);

--- a/src/Crate/PDO/PDOStatement.php
+++ b/src/Crate/PDO/PDOStatement.php
@@ -215,8 +215,8 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
         $result = $this->request->__invoke($this, $this->sql, $params);
 
         if (is_array($result)) {
-            $this->errorCode    = $result['code'];
-            $this->errorMessage = $result['message'];
+            $this->errorCode    = strval($result['code']);
+            $this->errorMessage = strval($result['message']);
 
             return false;
         }
@@ -486,23 +486,26 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function errorCode()
+    public function errorCode(): ?string
     {
         return $this->errorCode;
     }
 
     /**
      * {@inheritDoc}
+     *
+     * @return array|null
      */
+    #[\ReturnTypeWillChange]
     public function errorInfo()
     {
         if ($this->errorCode === null) {
-            return null;
+            return ["00000", null, null];
         }
 
         switch ($this->errorCode) {
             case CrateConst::ERR_INVALID_SQL:
-                $ansiErrorCode = 42000;
+                $ansiErrorCode = '42000';
                 break;
 
             default:
@@ -511,9 +514,9 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
         }
 
         return [
-            $ansiErrorCode,
-            $this->errorCode,
-            $this->errorMessage,
+            strval($ansiErrorCode),
+            intval($this->errorCode),
+            strval($this->errorMessage),
         ];
     }
 
@@ -620,7 +623,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
      */
     public function closeCursor(): bool
     {
-        $this->errorCode  = 0;
+        $this->errorCode  = null;
         $this->collection = null;
 
         return true;

--- a/src/Crate/PDO/PDOStatement.php
+++ b/src/Crate/PDO/PDOStatement.php
@@ -247,6 +247,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function fetch($fetch_style = null, $cursor_orientation = PDO::FETCH_ORI_NEXT, $cursor_offset = 0)
     {
         if (!$this->hasExecuted()) {
@@ -296,6 +297,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function bindParam(
         $parameter,
         &$variable,
@@ -327,6 +329,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null)
     {
         $type = $type ?: PDO::PARAM_STR;
@@ -342,16 +345,17 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function bindValue($parameter, $value, $data_type = PDO::PARAM_STR)
+    public function bindValue($parameter, $value, int $data_type = PDO::PARAM_STR): bool
     {
         $value = $this->typedValue($value, $data_type);
         $this->bindParam($parameter, $value, $data_type);
+        return true;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function rowCount()
+    public function rowCount(): int
     {
         if (!$this->hasExecuted()) {
             $this->execute();
@@ -367,7 +371,8 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function fetchColumn($column_number = 0)
+    #[\ReturnTypeWillChange]
+    public function fetchColumn(int $column_number = 0)
     {
         if (!is_int($column_number)) {
             throw new Exception\InvalidArgumentException('column_number must be a valid integer');
@@ -472,6 +477,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function fetchObject($class_name = null, $ctor_args = null)
     {
         throw new Exception\UnsupportedException;
@@ -514,7 +520,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function setAttribute($attribute, $value)
+    public function setAttribute(int $attribute, $value): bool
     {
         throw new Exception\UnsupportedException('This driver doesn\'t support setting attributes');
     }
@@ -522,7 +528,8 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function getAttribute($attribute)
+    #[\ReturnTypeWillChange]
+    public function getAttribute(int $attribute)
     {
         throw new Exception\UnsupportedException('This driver doesn\'t support getting attributes');
     }
@@ -530,7 +537,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function columnCount()
+    public function columnCount(): int
     {
         if (!$this->hasExecuted()) {
             $this->execute();
@@ -542,7 +549,8 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function getColumnMeta($column)
+    #[\ReturnTypeWillChange]
+    public function getColumnMeta(int $column)
     {
         throw new Exception\UnsupportedException;
     }
@@ -592,7 +600,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function nextRowset()
+    public function nextRowset(): bool
     {
         if (!$this->hasExecuted()) {
             $this->execute();
@@ -610,7 +618,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function closeCursor()
+    public function closeCursor(): bool
     {
         $this->errorCode  = 0;
         $this->collection = null;
@@ -621,7 +629,7 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function debugDumpParams()
+    public function debugDumpParams(): ?bool
     {
         throw new Exception\UnsupportedException('Not supported, use var_dump($stmt) instead');
     }

--- a/src/Crate/PDO/PDOStatement.php
+++ b/src/Crate/PDO/PDOStatement.php
@@ -345,8 +345,8 @@ class PDOStatement extends BasePDOStatement implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function bindValue($parameter, $value, int $data_type = PDO::PARAM_STR): bool
     #[\ReturnTypeWillChange]
+    public function bindValue($parameter, $value, $data_type = PDO::PARAM_STR)
     {
         $value = $this->typedValue($value, $data_type);
         $this->bindParam($parameter, $value, $data_type);

--- a/src/Crate/PDO/PDOStatementImplementationPhp8.php
+++ b/src/Crate/PDO/PDOStatementImplementationPhp8.php
@@ -50,6 +50,7 @@ trait PDOStatementImplementationPhp8
      *
      * @return mixed[]
      */
+    #[\ReturnTypeWillChange]
     public function fetchAll(int $mode = null, ...$args)
     {
         return $this->doFetchAll($mode, ...$args);

--- a/src/Crate/Stdlib/BulkResponse.php
+++ b/src/Crate/Stdlib/BulkResponse.php
@@ -124,6 +124,7 @@ final class BulkResponse implements BulkResponseInterface
     /**
      * {@Inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->results);

--- a/src/Crate/Stdlib/Collection.php
+++ b/src/Crate/Stdlib/Collection.php
@@ -105,6 +105,7 @@ final class Collection implements CollectionInterface
     /**
      * {@Inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->rows);
@@ -113,7 +114,7 @@ final class Collection implements CollectionInterface
     /**
      * {@Inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         next($this->rows);
     }
@@ -121,6 +122,7 @@ final class Collection implements CollectionInterface
     /**
      * {@Inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->rows);
@@ -129,7 +131,7 @@ final class Collection implements CollectionInterface
     /**
      * {@Inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->key() !== null;
     }
@@ -137,7 +139,7 @@ final class Collection implements CollectionInterface
     /**
      * {@Inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->rows);
     }
@@ -145,7 +147,7 @@ final class Collection implements CollectionInterface
     /**
      * {@Inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         return $this->rowCount;
     }

--- a/test/CrateIntegrationTest/PDO/PDOStatementTest.php
+++ b/test/CrateIntegrationTest/PDO/PDOStatementTest.php
@@ -380,11 +380,11 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement = $this->pdo->prepare("INSERT INTO test_table (name) VALUES ('hello')");
         $statement->execute();
 
-        $this->assertEquals(4000, $statement->errorCode());
+        $this->assertEquals('4000', $statement->errorCode());
 
         list ($ansiSQLError, $driverError, $driverMessage) = $statement->errorInfo();
 
-        $this->assertEquals(42000, $ansiSQLError);
+        $this->assertEquals('42000', $ansiSQLError);
         $this->assertEquals(CrateConst::ERR_INVALID_SQL, $driverError);
         $this->assertStringContainsString('SQLParseException[Column `id` is required but is missing from the insert statement]', $driverMessage);
     }

--- a/test/CrateIntegrationTest/PDO/PDOTest.php
+++ b/test/CrateIntegrationTest/PDO/PDOTest.php
@@ -72,4 +72,11 @@ class PDOTest extends AbstractIntegrationTest
         $result = $this->pdo->getServerVersion();
         $this->assertMatchesRegularExpression("/[0-9]+\.[0-9]+\.[0-9]+/", $result);
     }
+
+    public function testGetServerInfo()
+    {
+        $result = $this->pdo->getServerInfo();
+        $this->assertMatchesRegularExpression("/[0-9]+\.[0-9]+\.[0-9]+/", $result);
+    }
+
 }

--- a/test/CrateIntegrationTest/PDO/PDOTest.php
+++ b/test/CrateIntegrationTest/PDO/PDOTest.php
@@ -38,11 +38,11 @@ class PDOTest extends AbstractIntegrationTest
         $statement = $this->pdo->prepare('bogus sql');
         $statement->execute();
 
-        $this->assertEquals(4000, $statement->errorCode());
+        $this->assertEquals('4000', $statement->errorCode());
 
         list ($ansiSQLError, $driverError, $driverMessage) = $statement->errorInfo();
 
-        $this->assertEquals(42000, $ansiSQLError);
+        $this->assertEquals('42000', $ansiSQLError);
         $this->assertEquals(CrateConst::ERR_INVALID_SQL, $driverError);
         $this->assertStringContainsString('mismatched input \'bogus\'', $driverMessage);
     }

--- a/test/CrateTest/PDO/PDOStatementTest.php
+++ b/test/CrateTest/PDO/PDOStatementTest.php
@@ -654,9 +654,9 @@ class PDOStatementTest extends TestCase
 
         $property = $reflection->getProperty('errorCode');
         $property->setAccessible(true);
-        $property->setValue($this->statement, 1337);
+        $property->setValue($this->statement, '1337');
 
-        $this->assertEquals(1337, $this->statement->errorCode());
+        $this->assertEquals('1337', $this->statement->errorCode());
     }
 
     /**
@@ -665,7 +665,7 @@ class PDOStatementTest extends TestCase
     public function errorInfoAnsiCodeProvider()
     {
         return [
-            [42000, CrateConst::ERR_INVALID_SQL, 'le error message'],
+            ['42000', CrateConst::ERR_INVALID_SQL, 'le error message'],
             ['Not available', 1337, 'le error message'],
         ];
     }
@@ -674,14 +674,25 @@ class PDOStatementTest extends TestCase
      * @covers ::errorInfo
      * @dataProvider errorInfoAnsiCodeProvider
      *
-     * @param mixed  $ansiCode
-     * @param int    $errorCode
+     * @param string $ansiCode
+     * @param int $errorCode
      * @param string $errorMessage
      */
-    public function testErrorInfo($ansiCode, $errorCode, $errorMessage)
+    public function testErrorInfoUndefined($ansiCode, $errorCode, $errorMessage)
     {
-        $this->assertNull($this->statement->errorInfo());
+        $this->assertEquals(["00000", null, null], $this->statement->errorInfo());
+    }
 
+    /**
+     * @covers ::errorInfo
+     * @dataProvider errorInfoAnsiCodeProvider
+     *
+     * @param string $ansiCode
+     * @param int $errorCode
+     * @param string $errorMessage
+     */
+    public function testErrorInfoDefined($ansiCode, $errorCode, $errorMessage)
+    {
         $reflection = new ReflectionClass(PDOStatement::class);
 
         $errorCodeProp = $reflection->getProperty('errorCode');

--- a/test/CrateTest/PDO/PDOStatementTest.php
+++ b/test/CrateTest/PDO/PDOStatementTest.php
@@ -361,11 +361,7 @@ class PDOStatementTest extends TestCase
      */
     public function testFetchColumnWithInvalidColumnNumberType()
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->expectException(\TypeError::class);
-        } else {
-            $this->expectException('Crate\PDO\Exception\InvalidArgumentException');
-        }
+        $this->expectException('Crate\PDO\Exception\InvalidArgumentException');
         $this->statement->fetchColumn('test');
     }
 
@@ -711,11 +707,7 @@ class PDOStatementTest extends TestCase
      */
     public function testGetAttribute()
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->expectException(\TypeError::class);
-        } else {
-            $this->expectException(UnsupportedException::class);
-        }
+        $this->expectException(UnsupportedException::class);
         $this->statement->getAttribute(null, null);
     }
 
@@ -724,11 +716,7 @@ class PDOStatementTest extends TestCase
      */
     public function testSetAttribute()
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->expectException(\TypeError::class);
-        } else {
-            $this->expectException(UnsupportedException::class);
-        }
+        $this->expectException(UnsupportedException::class);
         $this->statement->setAttribute(null, null);
     }
 
@@ -760,11 +748,7 @@ class PDOStatementTest extends TestCase
      */
     public function testGetColumnMeta()
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->expectException(\TypeError::class);
-        } else {
-            $this->expectException(UnsupportedException::class);
-        }
+        $this->expectException(UnsupportedException::class);
         $this->statement->getColumnMeta(null);
     }
 

--- a/test/CrateTest/PDO/PDOStatementTest.php
+++ b/test/CrateTest/PDO/PDOStatementTest.php
@@ -361,7 +361,11 @@ class PDOStatementTest extends TestCase
      */
     public function testFetchColumnWithInvalidColumnNumberType()
     {
-        $this->expectException('Crate\PDO\Exception\InvalidArgumentException');
+        if (PHP_VERSION_ID >= 80000) {
+            $this->expectException(\TypeError::class);
+        } else {
+            $this->expectException('Crate\PDO\Exception\InvalidArgumentException');
+        }
         $this->statement->fetchColumn('test');
     }
 
@@ -696,7 +700,11 @@ class PDOStatementTest extends TestCase
      */
     public function testGetAttribute()
     {
-        $this->expectException(UnsupportedException::class);
+        if (PHP_VERSION_ID >= 80000) {
+            $this->expectException(\TypeError::class);
+        } else {
+            $this->expectException(UnsupportedException::class);
+        }
         $this->statement->getAttribute(null, null);
     }
 
@@ -705,7 +713,11 @@ class PDOStatementTest extends TestCase
      */
     public function testSetAttribute()
     {
-        $this->expectException(UnsupportedException::class);
+        if (PHP_VERSION_ID >= 80000) {
+            $this->expectException(\TypeError::class);
+        } else {
+            $this->expectException(UnsupportedException::class);
+        }
         $this->statement->setAttribute(null, null);
     }
 
@@ -737,7 +749,11 @@ class PDOStatementTest extends TestCase
      */
     public function testGetColumnMeta()
     {
-        $this->expectException(UnsupportedException::class);
+        if (PHP_VERSION_ID >= 80000) {
+            $this->expectException(\TypeError::class);
+        } else {
+            $this->expectException(UnsupportedException::class);
+        }
         $this->statement->getColumnMeta(null);
     }
 

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -107,7 +107,11 @@ class PDOTest extends TestCase
      */
     public function testGetAttributeWithInvalidAttribute()
     {
-        $this->expectException(PDOException::class);
+        if (PHP_VERSION_ID >= 80000) {
+            $this->expectException(\TypeError::class);
+        } else {
+            $this->expectException(PDOException::class);
+        }
         $this->pdo->getAttribute('I DONT EXIST');
     }
 
@@ -116,7 +120,11 @@ class PDOTest extends TestCase
      */
     public function testSetAttributeWithInvalidAttribute()
     {
-        $this->expectException(PDOException::class);
+        if (PHP_VERSION_ID >= 80000) {
+            $this->expectException(\TypeError::class);
+        } else {
+            $this->expectException(PDOException::class);
+        }
         $this->pdo->setAttribute('I DONT EXIST', 'value');
     }
 

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -107,11 +107,7 @@ class PDOTest extends TestCase
      */
     public function testGetAttributeWithInvalidAttribute()
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->expectException(\TypeError::class);
-        } else {
-            $this->expectException(PDOException::class);
-        }
+        $this->expectException(PDOException::class);
         $this->pdo->getAttribute('I DONT EXIST');
     }
 
@@ -120,11 +116,7 @@ class PDOTest extends TestCase
      */
     public function testSetAttributeWithInvalidAttribute()
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->expectException(\TypeError::class);
-        } else {
-            $this->expectException(PDOException::class);
-        }
+        $this->expectException(PDOException::class);
         $this->pdo->setAttribute('I DONT EXIST', 'value');
     }
 

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -24,6 +24,7 @@ namespace CrateTest\PDO;
 
 use Crate\PDO\Exception\InvalidArgumentException;
 use Crate\PDO\Exception\PDOException;
+use Crate\PDO\Exception\LogicException;
 use Crate\PDO\Exception\UnsupportedException;
 use Crate\PDO\Http\ServerInterface;
 use Crate\PDO\PDO;
@@ -404,6 +405,25 @@ class PDOTest extends TestCase
         $this->assertEquals(E_USER_DEPRECATED, $errno, 'E_USER_DEPRECATED has not been triggered');
         $this->stringStartsWith('`crate/crate-pdo` will stop supporting PHP7', $errstr, 'PHP7 deprecation not issued');
 
+    }
+
+    public function testExec()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage("The statement has not been executed yet");
+        $this->pdo->exec("SELECT 1;");
+    }
+
+    public function testErrorCode()
+    {
+        $pdo = new PDO('crate:localhost:1234', null, null, []);
+        $this->assertEquals(0, $pdo->errorCode());
+    }
+
+    public function testErrorInfo()
+    {
+        $pdo = new PDO('crate:localhost:1234', null, null, []);
+        $this->assertEquals(["00000", null, null], $pdo->errorInfo());
     }
 
 }


### PR DESCRIPTION
### About
Running the standalone example programs added with GH-145 **revealed lots of deprecation warnings and subsequent type errors**.

### Details
1. Maintenance: Towards PHP8, by adding more type hints.
2. Maintenance: Align `PDO::errorCode()` with official PDO specification [^1].
   According to the specification, the function should return either an error code as string type, or `null`. Its signature is:
   ```
   public PDO::errorCode(): ?string
   ```
   On the other hand, our implementation returned `int` error codes. This changed now, and has been advertised properly as breaking change. Personally, I don't think it will have too much impact, as most error handling in userspace programs will be handled by exceptions anyway, as far as I could see, and within [`CrateConst.php`](https://github.com/crate/crate-pdo/blob/main/src/Crate/Stdlib/CrateConst.php), it looks like only `ERR_INVALID_SQL` had internal references at all. Please advise if you think this flaw should not be fixed, or differently.

[^1]: https://www.php.net/manual/en/pdo.errorcode.php
