### PR TITLE
Maintenance: Add deprecation notice about PHP7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 - Added support for `CrateDB bulk operations`_, for improved efficiency on
   DML operations.
 
+- Added deprecation notice about PHP7.
+
 .. _CrateDB bulk operations: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
 
 2022/11/29 2.1.4

--- a/src/Crate/PDO/PDO.php
+++ b/src/Crate/PDO/PDO.php
@@ -31,6 +31,8 @@ use Crate\PDO\Http\ServerPool;
 use Crate\Stdlib\ArrayUtils;
 use PDO as BasePDO;
 
+use const PHP_VERSION_ID;
+
 class PDO extends BasePDO implements PDOInterface
 {
     use PDOImplementation;
@@ -102,6 +104,15 @@ class PDO extends BasePDO implements PDOInterface
      */
     public function __construct($dsn, $username = null, $passwd = null, $options = [])
     {
+
+        if (PHP_VERSION_ID < 80000) {
+            trigger_error(
+                "`crate/crate-pdo` will stop supporting PHP7 on one of the upcoming " .
+                "releases. Please upgrade to PHP8.",
+                E_USER_DEPRECATED
+            );
+        }
+
         $dsnParts = self::parseDSN($dsn);
         $servers  = self::serversFromDsnParts($dsnParts);
 


### PR DESCRIPTION
This patch adds a deprecation warning, saying that this driver will stop supporting PHP7 in the future.

/cc @hammerhead, @hlcianfagna 