### PR TITLE
CI: Use `docker compose` instead of `docker-compose`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,10 @@ jobs:
           fetch-depth: 2
 
       # With GHA's "services", you cannot map volumes to your codebase BEFORE checking out the codebase.
-      # So, let's use `docker-compose` to bring in services AFTER checking out the code.
+      # So, let's use `docker compose` to bring in services AFTER checking out the code.
       # https://github.community/t/services-and-volumes/16313
       - name: Run CrateDB
-        run: docker-compose --file test/provisioning/docker-compose.yml up --detach
+        run: docker compose --file test/provisioning/docker-compose.yml up --detach
 
       # https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
@@ -77,4 +77,4 @@ jobs:
       # https://github.community/t/how-do-i-get-the-logs-for-a-service/16422
       - name: The job has failed
         if: failure()
-        run: docker-compose --file test/provisioning/docker-compose.yml logs
+        run: docker compose --file test/provisioning/docker-compose.yml logs

--- a/test/provisioning/docker-compose.yml
+++ b/test/provisioning/docker-compose.yml
@@ -1,8 +1,6 @@
 # Purpose:
 # Start CrateDB with custom parameters and wait for the service being available,
-# even when invoked through `docker-compose up --detach`.
-
-version: '3'
+# even when invoked through `docker compose up --detach`.
 
 services:
 


### PR DESCRIPTION
Docker Compose v1 has been removed from GHA runners.
