### PR TITLE
CI: Verify support on PHP 8.4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
   schedule:
     - cron: '0 7 * * *'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
   # Allow job to be triggered manually.
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
-        php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     name: PHP ${{ matrix.php-version }} on OS ${{ matrix.os }}
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog for crate-pdo
 Unreleased
 ==========
 
+- Verified support on PHP 8.4
+
 2023/05/09 2.2.0
 ================
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/crate/crate-pdo",
     "keywords": ["database", "pdo", "cratedb"],
     "require": {
-        "php":     "^7.3|^8.0|^8.1|^8.2|^8.3",
+        "php":     "^7.3|^8.0|^8.1|^8.2|^8.3|^8.4",
         "ext-pdo": "*",
         "guzzlehttp/guzzle": "^7.2"
     },


### PR DESCRIPTION
## About
PHP 8.4 has been released on Nov 21, 2024.

## References
- GH-160
