### PR TITLE
CI: Don't fail the test matrix early, for a better overview

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ] #, macos-latest, windows-latest ]
         php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]


### PR DESCRIPTION
Adjust test matrix configuration to always invoke all test matrix slots.