### PR TITLE
Dependencies: Fix a few deprecation warnings on function signatures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog for crate-pdo
 Unreleased
 ==========
 
+- Dependencies: Fixed deprecation warnings on function signatures
+  ``PDOCrateDB::prepare``, ``PDOCrateDB::lastInsertId``, ``PDOCrateDB::quote``,
+  and ``PDOStatementImplementationPhp8::query``.
+
 2025/11/13 2.2.3
 ================
 

--- a/src/Crate/PDO/PDOCrateDB.php
+++ b/src/Crate/PDO/PDOCrateDB.php
@@ -207,7 +207,7 @@ class PDOCrateDB extends BasePDO implements PDOInterface
      * {@inheritDoc}
      */
     #[\ReturnTypeWillChange]
-    public function prepare(string $statement, array $options = [])
+    public function prepare($statement, $options = null)
     {
         $options = ArrayUtils::toArray($options);
 
@@ -280,7 +280,7 @@ class PDOCrateDB extends BasePDO implements PDOInterface
     /**
      * {@inheritDoc}
      */
-    public function lastInsertId(?string $name = null): string
+    public function lastInsertId($name = null): string
     {
         throw new Exception\UnsupportedException;
     }
@@ -456,7 +456,7 @@ class PDOCrateDB extends BasePDO implements PDOInterface
      * {@inheritDoc}
      */
     #[\ReturnTypeWillChange]
-    public function quote(string $string, int $parameter_type = self::PARAM_STR)
+    public function quote($string, $parameter_type = self::PARAM_STR)
     {
         switch ($parameter_type) {
             case self::PARAM_INT:

--- a/src/Crate/PDO/PDOImplementationPhp8.php
+++ b/src/Crate/PDO/PDOImplementationPhp8.php
@@ -35,9 +35,9 @@ trait PDOImplementationPhp8
      * @param string|null $query
      * @param int|null $fetchMode
      * @param mixed ...$fetchModeArgs
-     * @return PDOStatement
+     * @return PDOStatement|false
      */
-    public function query(?string $query = null, ?int $fetchMode = null, mixed ...$fetchModeArgs): PDOStatement
+    public function query(?string $query = null, ?int $fetchMode = null, mixed ...$fetchModeArgs): PDOStatement|false
     {
         if ($fetchMode !== null) {
             throw new UnsupportedException('PDOCrateDB::query $fetchMode not implemented yet');


### PR DESCRIPTION
## Locations
- `PDOCrateDB::prepare`
- `PDOCrateDB::lastInsertId`
- `PDOCrateDB::quote`
- `PDOStatementImplementationPhp8::query`?

## Details
```php
PHP Warning:  Declaration of Crate\PDO\PDOCrateDB::prepare(string $statement, array $options = Array) should be compatible with PDO::prepare($statement, $options = NULL) in /home/runner/work/crate-pdo/crate-pdo/src/Crate/PDO/PDOCrateDB.php on line 36
PHP Warning:  Declaration of Crate\PDO\PDOCrateDB::lastInsertId(?string $name = NULL): string should be compatible with PDO::lastInsertId($seqname = NULL) in /home/runner/work/crate-pdo/crate-pdo/src/Crate/PDO/PDOCrateDB.php on line 36
PHP Warning:  Declaration of Crate\PDO\PDOCrateDB::quote(string $string, int $parameter_type = self::PARAM_STR) should be compatible with PDO::quote($string, $paramtype = NULL) in /home/runner/work/crate-pdo/crate-pdo/src/Crate/PDO/PDOCrateDB.php on line 36
```

## References
- https://github.com/crate/crate-pdo/issues/173#issuecomment-3523495628
- GH-174
