### PR TITLE
CI: Downgrade to Composer 2.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: composer, phpunit:^9.5
+          tools: composer:2.8, phpunit:^9.5
 
       - uses: ramsey/composer-install@v2
 


### PR DESCRIPTION
## Problem

Composer 2.9 started failing on PHP 7:
```php
Undefined property: Composer\BinProxyWrapper::$realpath
```

## References

https://github.com/crate/crate-pdo/actions/runs/19332402311/job/55298461556?pr=177