### PR TITLE
Maintenance: Verify support on PHP 8.5 and PHP 8.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
           '8.3',
           '8.4',
           '8.5',
+          '8.6',
         ]
 
     name: PHP ${{ matrix.php-version }} on OS ${{ matrix.os }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Unreleased
   when prepared statements can't be used.
 - Standards: Adjusted interface signature for ``PDO::query``;
   the ``query`` argument is no longer optional.
-- Verified support on PHP 8.5
+- Verified support on PHP 8.5 and PHP 8.6
 
 2025/11/13 2.2.3
 ================

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ CrateDB PDO Adapter
     :target: https://packagist.org/packages/crate/crate-pdo
     :alt: Latest stable version
 
-.. image:: https://img.shields.io/badge/PHP-7.3%2C%207.4%2C%208.0%2C%208.1%2C%208.2%2C%208.3%2C%208.4%2C%208.5-green.svg
+.. image:: https://img.shields.io/badge/PHP-7.3%2C%207.4%2C%208.0%2C%208.1%2C%208.2%2C%208.3%2C%208.4%2C%208.5%2C%208.6-green.svg
     :target: https://packagist.org/packages/crate/crate-pdo
     :alt: Supported PHP versions
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/crate/crate-pdo",
     "keywords": ["database", "pdo", "cratedb"],
     "require": {
-        "php":     "^7.3|^7.4|^8.0|^8.1|^8.2|^8.3|^8.4|^8.5",
+        "php":     "^7.3|^7.4|^8.0|^8.1|^8.2|^8.3|^8.4|^8.5|^8.6",
         "ext-pdo": "*",
         "guzzlehttp/guzzle": "^7.2"
     },


### PR DESCRIPTION
- [PHP 8.5.0 RC4 available for testing](https://www.php.net/archive/2025.php#2025-11-06-1) (06 Nov 2025)
- [PHP 8.5: What's New and Changed](https://php.watch/versions/8.5)