### PR TITLE
Quoting: Start supporting `PDOCrateDB::quote(..., \PDO::PARAM_STR)`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 - Dependencies: Fixed deprecation warnings on function signatures
   ``PDOCrateDB::prepare``, ``PDOCrateDB::lastInsertId``, ``PDOCrateDB::quote``,
   and ``PDOStatementImplementationPhp8::query``.
+- Quoting: Started supporting ``PDOCrateDB::quote(..., \PDO::PARAM_STR)``
+  when prepared statements can't be used.
 
 2025/11/13 2.2.3
 ================

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -235,6 +235,8 @@ class PDOTest extends TestCase
 
         $this->assertEquals(100, $this->pdo->quote('100', PDOCrateDB::PARAM_INT));
         $this->assertNull($this->pdo->quote('helloWorld', PDOCrateDB::PARAM_NULL));
+
+        $this->assertEquals("Don''t bother", $this->pdo->quote("Don't bother", \PDO::PARAM_STR));
     }
 
     /**
@@ -244,7 +246,6 @@ class PDOTest extends TestCase
     {
         return [
             [PDOCrateDB::PARAM_LOB, PDOException::class, 'This is not supported by crate.io'],
-            [PDOCrateDB::PARAM_STR, PDOException::class, 'This is not supported, please use prepared statements.'],
             [120, InvalidArgumentException::class, 'Unknown param type'],
         ];
     }


### PR DESCRIPTION
## Problem
While prepared statements are always preferred, PHP clients that don't use them would otherwise be unsupported.

## Solution
Add escaping/quoting function, but emit a deprecation warning.

## References
- GH-87