### PR TITLE
Standards: Start referring to canonical `PDO::` symbols where possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
 - Standards: Adjusted interface signature for ``PDO::query``;
   the ``query`` argument is no longer optional.
 - Verified support on PHP 8.5 and PHP 8.6
+- Standards: Started referring to canonical ``PDO::`` symbols where possible,
+  using ``PDOCrateDB::`` only for CrateDB specifics.
 
 2025/11/13 2.2.3
 ================

--- a/src/Crate/PDO/Http/ServerPool.php
+++ b/src/Crate/PDO/Http/ServerPool.php
@@ -36,6 +36,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\RequestOptions;
+use PDO;
 
 /**
  * Class ServerPool
@@ -220,8 +221,8 @@ final class ServerPool implements ServerInterface
         $protocol = $sslMode === PDOCrateDB::CRATE_ATTR_SSL_MODE_DISABLED ? 'http' : 'https';
 
         $options = [
-            RequestOptions::TIMEOUT         => $pdo->getAttribute(PDOCrateDB::ATTR_TIMEOUT),
-            RequestOptions::CONNECT_TIMEOUT => $pdo->getAttribute(PDOCrateDB::ATTR_TIMEOUT),
+            RequestOptions::TIMEOUT         => $pdo->getAttribute(PDO::ATTR_TIMEOUT),
+            RequestOptions::CONNECT_TIMEOUT => $pdo->getAttribute(PDO::ATTR_TIMEOUT),
             RequestOptions::AUTH            => $pdo->getAttribute(PDOCrateDB::CRATE_ATTR_HTTP_BASIC_AUTH) ?: null,
             RequestOptions::HEADERS         => [
                 'Default-Schema' => $pdo->getAttribute(PDOCrateDB::CRATE_ATTR_DEFAULT_SCHEMA),

--- a/test/CrateIntegrationTest/PDO/PDOStatementTest.php
+++ b/test/CrateIntegrationTest/PDO/PDOStatementTest.php
@@ -25,6 +25,7 @@ namespace CrateIntegrationTest\PDO;
 use Crate\PDO\PDOCrateDB;
 use Crate\Stdlib\BulkResponse;
 use Crate\Stdlib\CrateConst;
+use PDO;
 
 /**
  * Class PDOStatementTest
@@ -70,7 +71,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement->bindColumn('id', $id);
         $statement->bindColumn('name', $name);
 
-        while ($row = $statement->fetch(PDOCrateDB::FETCH_BOUND)) {
+        while ($row = $statement->fetch(PDO::FETCH_BOUND)) {
 
             $this->assertEquals($expected[$index]['id'], $id);
             $this->assertEquals($expected[$index]['name'], $name);
@@ -96,7 +97,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement = $this->pdo->prepare('SELECT id, name FROM test_table');
         $statement->execute();
 
-        $this->assertEquals($expected, $statement->fetchAll(PDOCrateDB::FETCH_NUM));
+        $this->assertEquals($expected, $statement->fetchAll(PDO::FETCH_NUM));
     }
 
     public function testFetchAllWithAssocStyle()
@@ -114,7 +115,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement = $this->pdo->prepare('SELECT id, name FROM test_table');
         $statement->execute();
 
-        $this->assertEquals($expected, $statement->fetchAll(PDOCrateDB::FETCH_ASSOC));
+        $this->assertEquals($expected, $statement->fetchAll(PDO::FETCH_ASSOC));
     }
 
     public function testFetchAllWithObjectStyle()
@@ -132,7 +133,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement = $this->pdo->prepare('SELECT id, name FROM test_table');
         $statement->execute();
 
-        $this->assertEquals($expected, $statement->fetchAll(PDOCrateDB::FETCH_OBJ));
+        $this->assertEquals($expected, $statement->fetchAll(PDO::FETCH_OBJ));
     }
 
     public function testFetchSameColumnTwiceWithAssocStyle()
@@ -147,7 +148,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement = $this->pdo->prepare('SELECT id, id FROM test_table');
         $statement->execute();
 
-        $this->assertEquals($expected, $statement->fetchAll(PDOCrateDB::FETCH_ASSOC));
+        $this->assertEquals($expected, $statement->fetchAll(PDO::FETCH_ASSOC));
     }
 
     public function testFetchAllWithBothStyle()
@@ -166,7 +167,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement->execute();
 
         // In theory this should be assertSame, but implementing that would be incredibly slow
-        $this->assertEquals($expected, $statement->fetchAll(PDOCrateDB::FETCH_BOTH));
+        $this->assertEquals($expected, $statement->fetchAll(PDO::FETCH_BOTH));
     }
 
     public function testFetchAllWithFuncStyle()
@@ -189,7 +190,7 @@ class PDOStatementTest extends AbstractIntegrationTest
             return sprintf('%d:%s', $id, $name);
         };
 
-        $resultSet = $statement->fetchAll(PDOCrateDB::FETCH_FUNC, $callback);
+        $resultSet = $statement->fetchAll(PDO::FETCH_FUNC, $callback);
 
         foreach ($resultSet as $result) {
             $this->assertEquals(sprintf('%d:%s', $expected[$index]['id'], $expected[$index]['name']), $result);
@@ -217,7 +218,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement->execute();
         $this->assertEquals(1, $statement->rowCount());
 
-        $resultSet = $statement->fetchAll(PDOCrateDB::FETCH_NAMED);
+        $resultSet = $statement->fetchAll(PDO::FETCH_NAMED);
         $this->assertEquals(2, $resultSet[0]['id']);
         $this->assertEquals($name, $resultSet[0]['name']);
     }
@@ -244,7 +245,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement->execute();
         $this->assertEquals(1, $statement->rowCount());
 
-        $resultSet = $statement->fetchAll(PDOCrateDB::FETCH_NAMED);
+        $resultSet = $statement->fetchAll(PDO::FETCH_NAMED);
         $this->assertEquals(2, $resultSet[0]['id']);
         $this->assertEquals($name, $resultSet[0]['name']);
 
@@ -254,7 +255,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement->execute();
         $this->assertEquals(1, $statement->rowCount());
 
-        $resultSet = $statement->fetchAll(PDOCrateDB::FETCH_NAMED);
+        $resultSet = $statement->fetchAll(PDO::FETCH_NAMED);
         $this->assertEquals(2, $resultSet[0]['id']);
         $this->assertEquals($name, $resultSet[0]['name']);
     }
@@ -281,8 +282,8 @@ class PDOStatementTest extends AbstractIntegrationTest
         $this->pdo->exec("REFRESH TABLE test_table");
 
         $statement = $this->pdo->prepare('update test_table set name = concat(name, :name) where int_type = :int_type and name != :name');
-        $statement->bindValue(':int_type', 1, PDOCrateDB::PARAM_INT);
-        $statement->bindValue(':name', 'world', PDOCrateDB::PARAM_STR);
+        $statement->bindValue(':int_type', 1, PDO::PARAM_INT);
+        $statement->bindValue(':name', 'world', PDO::PARAM_STR);
         $statement->execute();
 
         $this->pdo->exec("REFRESH TABLE test_table");
@@ -311,15 +312,15 @@ class PDOStatementTest extends AbstractIntegrationTest
         $statement->execute();
         $this->assertEquals(1, $statement->rowCount());
 
-        $resultSet = $statement->fetchAll(PDOCrateDB::FETCH_NAMED);
+        $resultSet = $statement->fetchAll(PDO::FETCH_NAMED);
         $this->assertEquals(2, $resultSet[0]['id']);
         $this->assertEquals('second', $resultSet[0]['name']);
     }
 
     public function testArrayValue()
     {
-        $statement = $this->pdo->prepare('INSERT INTO test_table (id, array_type, object_type) VALUES(?, ?, ?)');
-        $statement->bindValue(1, 1, PDOCrateDB::PARAM_INT);
+        $statement = $this->pdo->prepare('INSERT INTO test_table (id, array_type, object_type) VALUES (?, ?, ?)');
+        $statement->bindValue(1, 1, PDO::PARAM_INT);
         $statement->bindValue(2, [1, 2], PDOCrateDB::PARAM_ARRAY);
         $statement->bindValue(3, ["foo" => "bar"], PDOCrateDB::PARAM_OBJECT);
         $statement->execute();
@@ -328,7 +329,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $this->pdo->exec('REFRESH TABLE test_table');
 
         $statement = $this->pdo->prepare('SELECT id, array_type, object_type FROM test_table');
-        $resultSet = $statement->fetchAll(PDOCrateDB::FETCH_ASSOC);
+        $resultSet = $statement->fetchAll(PDO::FETCH_ASSOC);
         $this->assertEquals(1, $resultSet[0]['id']);
         $this->assertEquals([1, 2], $resultSet[0]['array_type']);
         $this->assertEquals(["foo" => "bar"], $resultSet[0]['object_type']);
@@ -342,7 +343,7 @@ class PDOStatementTest extends AbstractIntegrationTest
         $this->pdo->exec('REFRESH TABLE test_table');
 
         $statement = $this->pdo->prepare('SELECT * FROM test_table');
-        $resultSet = $statement->fetchAll(PDOCrateDB::FETCH_NAMED);
+        $resultSet = $statement->fetchAll(PDO::FETCH_NAMED);
 
         $this->assertEquals(6, $resultSet[0]['id']);
         $this->assertEquals(NULL, $resultSet[0]['name']);
@@ -363,14 +364,14 @@ class PDOStatementTest extends AbstractIntegrationTest
         // Check outcome, response and result count, it is a `BulkResponse` instance here.
         // The `rowCount()` should be the total number of records.
         $this->assertTrue($outcome);
-        $response = $statement->fetchAll(PDOCrateDB::FETCH_NUM);
+        $response = $statement->fetchAll(PDO::FETCH_NUM);
         $this->assertEquals([["rowcount" => 1], ["rowcount" => 1], ["rowcount" => 1], ["rowcount" => 1]], $response);
         $this->assertEquals(4, $statement->rowCount());
 
         // Verify records have been inserted correctly.
         $this->pdo->exec("REFRESH TABLE test_table");
         $statement = $this->pdo->prepare("SELECT id, name, int_type FROM test_table ORDER BY id");
-        $results = $statement->fetchAll(PDOCrateDB::FETCH_NUM);
+        $results = $statement->fetchAll(PDO::FETCH_NUM);
         $this->assertEquals([5, 'foo', 1], $results[0]);
         $this->assertEquals([8, 'bar', 4], $results[3]);
     }
@@ -392,13 +393,13 @@ class PDOStatementTest extends AbstractIntegrationTest
     public function testNullParamBinding()
     {
         $statement = $this->pdo->prepare('INSERT INTO test_table (id, name) VALUES (6, ?)');
-        $statement->bindValue(1, NULL, PDOCrateDB::PARAM_STR);
+        $statement->bindValue(1, NULL, PDO::PARAM_STR);
         $statement->execute();
 
         $this->pdo->exec('REFRESH TABLE test_table');
 
         $statement = $this->pdo->prepare('SELECT * FROM test_table');
-        $resultSet = $statement->fetchAll(PDOCrateDB::FETCH_NAMED);
+        $resultSet = $statement->fetchAll(PDO::FETCH_NAMED);
 
         $this->assertEquals(6, $resultSet[0]['id']);
         $this->assertEquals(NULL, $resultSet[0]['name']);

--- a/test/CrateTest/PDO/Http/ServerPoolTest.php
+++ b/test/CrateTest/PDO/Http/ServerPoolTest.php
@@ -36,6 +36,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
+use PDO;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -71,7 +72,7 @@ final class ServerPoolTest extends TestCase
         return [
             [
                 [
-                    PDOCrateDB::ATTR_TIMEOUT               => 10,
+                    PDO::ATTR_TIMEOUT                      => 10,
                     PDOCrateDB::CRATE_ATTR_DEFAULT_SCHEMA  => 'default',
                     PDOCrateDB::CRATE_ATTR_HTTP_BASIC_AUTH => ['foo', 'bar'],
                 ],

--- a/test/CrateTest/PDO/PDOStatementTest.php
+++ b/test/CrateTest/PDO/PDOStatementTest.php
@@ -29,6 +29,7 @@ use Crate\PDO\PDOStatement;
 use Crate\Stdlib\Collection;
 use Crate\Stdlib\CollectionInterface;
 use Crate\Stdlib\CrateConst;
+use PDO;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass;
@@ -179,7 +180,7 @@ class PDOStatementTest extends TestCase
     {
         $column     = 'column';
         $value      = 'value1';
-        $type       = PDOCrateDB::PARAM_STR;
+        $type       = PDO::PARAM_STR;
         $maxlen     = 1000;
         $driverData = null;
 
@@ -203,18 +204,18 @@ class PDOStatementTest extends TestCase
     public function bindValueParameterProvider()
     {
         return [
-            [PDOCrateDB::PARAM_INT, '1', 1],
-            [PDOCrateDB::PARAM_NULL, '1', null],
-            [PDOCrateDB::PARAM_BOOL, '1', true],
-            [PDOCrateDB::PARAM_BOOL, 'false', false],
-            [PDOCrateDB::PARAM_BOOL, 'true', true],
-            [PDOCrateDB::PARAM_BOOL, '1', true],
-            [PDOCrateDB::PARAM_BOOL, '0', false],
-            [PDOCrateDB::PARAM_BOOL, '', false],
-            [PDOCrateDB::PARAM_STR, '1', '1'],
-            [PDOCrateDB::PARAM_INT, null, null],
+            [PDO::PARAM_INT, '1', 1],
+            [PDO::PARAM_NULL, '1', null],
+            [PDO::PARAM_BOOL, '1', true],
+            [PDO::PARAM_BOOL, 'false', false],
+            [PDO::PARAM_BOOL, 'true', true],
+            [PDO::PARAM_BOOL, '1', true],
+            [PDO::PARAM_BOOL, '0', false],
+            [PDO::PARAM_BOOL, '', false],
+            [PDO::PARAM_STR, '1', '1'],
+            [PDO::PARAM_INT, null, null],
             [PDOCrateDB::PARAM_TIMESTAMP, null, null],
-            [PDOCrateDB::PARAM_BOOL, null, null],
+            [PDO::PARAM_BOOL, null, null],
         ];
     }
 
@@ -263,7 +264,7 @@ class PDOStatementTest extends TestCase
 
         $this->callbackReturnValue = $collection;
 
-        $this->assertFalse($this->statement->fetch(PDOCrateDB::FETCH_NUM));
+        $this->assertFalse($this->statement->fetch(PDO::FETCH_NUM));
     }
 
     /**
@@ -275,9 +276,9 @@ class PDOStatementTest extends TestCase
         $name   = null;
         $active = null;
 
-        $this->statement->bindColumn('id', $id, PDOCrateDB::PARAM_INT);
-        $this->statement->bindColumn('name', $name, PDOCrateDB::PARAM_STR);
-        $this->statement->bindColumn('active', $active, PDOCrateDB::PARAM_BOOL);
+        $this->statement->bindColumn('id', $id, PDO::PARAM_INT);
+        $this->statement->bindColumn('name', $name, PDO::PARAM_STR);
+        $this->statement->bindColumn('active', $active, PDO::PARAM_BOOL);
 
         $this->assertNull($id);
         $this->assertNull($name);
@@ -285,13 +286,13 @@ class PDOStatementTest extends TestCase
 
         $this->callbackReturnValue = $this->getPopulatedCollection();
 
-        $this->statement->fetch(PDOCrateDB::FETCH_BOUND);
+        $this->statement->fetch(PDO::FETCH_BOUND);
 
         $this->assertSame(1, $id);
         $this->assertSame('foo', $name);
         $this->assertFalse($active);
 
-        $this->statement->fetch(PDOCrateDB::FETCH_BOUND);
+        $this->statement->fetch(PDO::FETCH_BOUND);
 
         $this->assertSame(2, $id);
         $this->assertSame('bar', $name);
@@ -301,10 +302,10 @@ class PDOStatementTest extends TestCase
     public function fetchStyleProvider()
     {
         return [
-            [PDOCrateDB::FETCH_NAMED, ['id' => 1, 'name' => 'foo', 'active' => false]],
-            [PDOCrateDB::FETCH_ASSOC, ['id' => 1, 'name' => 'foo', 'active' => false]],
-            [PDOCrateDB::FETCH_BOTH, [0 => 1, 1 => 'foo', 2 => false, 'id' => 1, 'name' => 'foo', 'active' => false]],
-            [PDOCrateDB::FETCH_NUM, [0 => 1, 1 => 'foo', 2 => false]],
+            [PDO::FETCH_NAMED, ['id' => 1, 'name' => 'foo', 'active' => false]],
+            [PDO::FETCH_ASSOC, ['id' => 1, 'name' => 'foo', 'active' => false]],
+            [PDO::FETCH_BOTH, [0 => 1, 1 => 'foo', 2 => false, 'id' => 1, 'name' => 'foo', 'active' => false]],
+            [PDO::FETCH_NUM, [0 => 1, 1 => 'foo', 2 => false]],
         ];
     }
 
@@ -333,7 +334,7 @@ class PDOStatementTest extends TestCase
 
         $this->callbackReturnValue = $this->getPopulatedCollection();
 
-        $this->statement->fetch(PDOCrateDB::FETCH_INTO);
+        $this->statement->fetch(PDO::FETCH_INTO);
     }
 
     /**
@@ -432,7 +433,7 @@ class PDOStatementTest extends TestCase
         $this->expectException(UnsupportedException::class);
         $this->callbackReturnValue = $this->getPopulatedCollection();
 
-        $this->statement->fetchAll(PDOCrateDB::FETCH_INTO);
+        $this->statement->fetchAll(PDO::FETCH_INTO);
     }
 
     /**
@@ -442,7 +443,7 @@ class PDOStatementTest extends TestCase
     {
         return [
             [
-                // Null mean it will use the default which is PDOCrateDB::FETCH_BOTH
+                // Null mean it will use the default which is PDO::FETCH_BOTH
                 null,
                 [
                     [
@@ -464,7 +465,7 @@ class PDOStatementTest extends TestCase
                 ],
             ],
             [
-                PDOCrateDB::FETCH_BOTH,
+                PDO::FETCH_BOTH,
                 [
                     [
                         0        => 1,
@@ -485,7 +486,7 @@ class PDOStatementTest extends TestCase
                 ],
             ],
             [
-                PDOCrateDB::FETCH_ASSOC,
+                PDO::FETCH_ASSOC,
                 [
                     [
                         'id'     => 1,
@@ -500,7 +501,7 @@ class PDOStatementTest extends TestCase
                 ],
             ],
             [
-                PDOCrateDB::FETCH_NAMED,
+                PDO::FETCH_NAMED,
                 [
                     [
                         'id'     => 1,
@@ -515,7 +516,7 @@ class PDOStatementTest extends TestCase
                 ],
             ],
             [
-                PDOCrateDB::FETCH_NUM,
+                PDO::FETCH_NUM,
                 [
                     [
                         0 => 1,
@@ -530,7 +531,7 @@ class PDOStatementTest extends TestCase
                 ],
             ],
             [
-                PDOCrateDB::FETCH_COLUMN,
+                PDO::FETCH_COLUMN,
                 [
                     1,
                     2,
@@ -555,8 +556,8 @@ class PDOStatementTest extends TestCase
         $this->pdo
             ->expects($this->any())
             ->method('getAttribute')
-            ->with(PDOCrateDB::ATTR_DEFAULT_FETCH_MODE)
-            ->will($this->returnValue(PDOCrateDB::FETCH_BOTH));
+            ->with(PDO::ATTR_DEFAULT_FETCH_MODE)
+            ->will($this->returnValue(PDO::FETCH_BOTH));
 
         $result = $this->statement->fetchAll($fetchStyle);
 
@@ -573,7 +574,7 @@ class PDOStatementTest extends TestCase
         $this->expectException('Crate\PDO\Exception\InvalidArgumentException');
         $this->callbackReturnValue = $this->getPopulatedCollection();
 
-        $this->statement->fetchAll(PDOCrateDB::FETCH_FUNC, 'void');
+        $this->statement->fetchAll(PDO::FETCH_FUNC, 'void');
     }
 
     /**
@@ -584,7 +585,7 @@ class PDOStatementTest extends TestCase
     {
         $columns                   = ['id', 'id', 'name'];
         $this->callbackReturnValue = new Collection([[1, 1, 'foo']], $columns, 0, 1);
-        $result                    = $this->statement->fetchAll(PDOCrateDB::FETCH_BOTH);
+        $result                    = $this->statement->fetchAll(PDO::FETCH_BOTH);
 
         $expected = [[0 => 1, 1 => 1, 2 => 'foo', 'id' => 1, 'id' => 1, 'name' => 'foo']];
         $this->assertEquals($expected, $result);
@@ -598,7 +599,7 @@ class PDOStatementTest extends TestCase
     {
         $this->callbackReturnValue = $this->getPopulatedCollection();
 
-        $result = $this->statement->fetchAll(PDOCrateDB::FETCH_FUNC, function ($id, $name, $active) {
+        $result = $this->statement->fetchAll(PDO::FETCH_FUNC, function ($id, $name, $active) {
             return $id;
         });
 
@@ -615,7 +616,7 @@ class PDOStatementTest extends TestCase
         $this->expectException('Crate\PDO\Exception\InvalidArgumentException');
         $this->callbackReturnValue = $this->getPopulatedCollection();
 
-        $this->statement->fetchAll(PDOCrateDB::FETCH_COLUMN, 'test');
+        $this->statement->fetchAll(PDO::FETCH_COLUMN, 'test');
     }
 
     /**
@@ -627,7 +628,7 @@ class PDOStatementTest extends TestCase
         $this->expectException('Crate\PDO\Exception\OutOfBoundsException');
         $this->callbackReturnValue = $this->getPopulatedCollection();
 
-        $this->statement->fetchAll(PDOCrateDB::FETCH_COLUMN, 100);
+        $this->statement->fetchAll(PDO::FETCH_COLUMN, 100);
     }
 
     /**
@@ -764,7 +765,7 @@ class PDOStatementTest extends TestCase
             'fetch mode requires the colno argument'
         );
 
-        $this->statement->setFetchMode(PDOCrateDB::FETCH_COLUMN);
+        $this->statement->setFetchMode(PDO::FETCH_COLUMN);
     }
 
     /**
@@ -779,7 +780,7 @@ class PDOStatementTest extends TestCase
             'colno must be an integer'
         );
 
-        $this->statement->setFetchMode(PDOCrateDB::FETCH_COLUMN, 'test');
+        $this->statement->setFetchMode(PDO::FETCH_COLUMN, 'test');
     }
 
     /**
@@ -788,7 +789,7 @@ class PDOStatementTest extends TestCase
      */
     public function testSetFetchModeWithColumn()
     {
-        $this->statement->setFetchMode(PDOCrateDB::FETCH_COLUMN, 1);
+        $this->statement->setFetchMode(PDO::FETCH_COLUMN, 1);
 
         $reflection = new ReflectionClass(PDOStatement::class);
 
@@ -797,18 +798,18 @@ class PDOStatementTest extends TestCase
 
         $options = $property->getValue($this->statement);
 
-        $this->assertEquals(PDOCrateDB::FETCH_COLUMN, $options['fetchMode']);
+        $this->assertEquals(PDO::FETCH_COLUMN, $options['fetchMode']);
         $this->assertEquals(1, $options['fetchColumn']);
     }
 
     public function fetchModeStyleProvider()
     {
         return [
-            [PDOCrateDB::FETCH_ASSOC],
-            [PDOCrateDB::FETCH_NUM],
-            [PDOCrateDB::FETCH_BOTH],
-            [PDOCrateDB::FETCH_BOUND],
-            [PDOCrateDB::FETCH_NAMED],
+            [PDO::FETCH_ASSOC],
+            [PDO::FETCH_NUM],
+            [PDO::FETCH_BOTH],
+            [PDO::FETCH_BOUND],
+            [PDO::FETCH_NAMED],
         ];
     }
 
@@ -840,7 +841,7 @@ class PDOStatementTest extends TestCase
     public function testSetFetchModeWithInvalidFetchStyle()
     {
         $this->expectException(UnsupportedException::class);
-        $this->statement->setFetchMode(PDOCrateDB::FETCH_INTO);
+        $this->statement->setFetchMode(PDO::FETCH_INTO);
     }
 
     /**
@@ -893,7 +894,7 @@ class PDOStatementTest extends TestCase
     public function testGetIterator()
     {
         $this->callbackReturnValue = $this->getPopulatedCollection();
-        $this->statement->setFetchMode(PDOCrateDB::FETCH_COLUMN, 0);
+        $this->statement->setFetchMode(PDO::FETCH_COLUMN, 0);
 
         $counter = 0;
 
@@ -923,13 +924,13 @@ class PDOStatementTest extends TestCase
         $this->assertEquals(1.23, $method->invoke($this->statement, 1.23, PDOCrateDB::PARAM_FLOAT));
         $this->assertEquals(1.23, $method->invoke($this->statement, 1.23, PDOCrateDB::PARAM_DOUBLE));
 
-        $this->assertEquals(1, $method->invoke($this->statement, 1, PDOCrateDB::PARAM_INT));
+        $this->assertEquals(1, $method->invoke($this->statement, 1, PDO::PARAM_INT));
         $this->assertEquals(1, $method->invoke($this->statement, 1, PDOCrateDB::PARAM_LONG));
 
-        $this->assertEquals(null, $method->invoke($this->statement, 1, PDOCrateDB::PARAM_NULL));
+        $this->assertEquals(null, $method->invoke($this->statement, 1, PDO::PARAM_NULL));
 
-        $this->assertEquals("hello", $method->invoke($this->statement, "hello", PDOCrateDB::PARAM_STR));
-        $this->assertEquals("1234", $method->invoke($this->statement, 1234, PDOCrateDB::PARAM_STR));
+        $this->assertEquals("hello", $method->invoke($this->statement, "hello", PDO::PARAM_STR));
+        $this->assertEquals("1234", $method->invoke($this->statement, 1234, PDO::PARAM_STR));
         $this->assertEquals("127.0.0.1", $method->invoke($this->statement, "127.0.0.1", PDOCrateDB::PARAM_IP));
 
         $this->assertEquals([1, 2], $method->invoke($this->statement, [1, 2], PDOCrateDB::PARAM_ARRAY));
@@ -950,7 +951,7 @@ class PDOStatementTest extends TestCase
         $method->setAccessible(true);
 
         $this->expectException('Crate\PDO\Exception\PDOException');
-        $method->invoke($this->statement, 1, PDOCrateDB::PARAM_LOB);
+        $method->invoke($this->statement, 1, PDO::PARAM_LOB);
     }
 
     /**

--- a/test/CrateTest/PDO/PDOTest.php
+++ b/test/CrateTest/PDO/PDOTest.php
@@ -30,6 +30,7 @@ use Crate\PDO\Http\ServerInterface;
 use Crate\PDO\PDOCrateDB;
 use Crate\PDO\PDOStatement;
 use Generator;
+use PDO;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -88,8 +89,8 @@ class PDOTest extends TestCase
      */
     public function testInstantiationWithTraversableOptions()
     {
-        $pdo = new PDOCrateDB('crate:localhost:1234', null, null, new \ArrayObject([PDOCrateDB::ATTR_ERRMODE => PDOCrateDB::ERRMODE_EXCEPTION]));
-        $this->assertEquals(PDOCrateDB::ERRMODE_EXCEPTION, $pdo->getAttribute(PDOCrateDB::ATTR_ERRMODE));
+        $pdo = new PDOCrateDB('crate:localhost:1234', null, null, new \ArrayObject([PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]));
+        $this->assertEquals(PDO::ERRMODE_EXCEPTION, $pdo->getAttribute(PDO::ATTR_ERRMODE));
     }
 
     /**
@@ -127,9 +128,9 @@ class PDOTest extends TestCase
      */
     public function testGetAndSetDefaultFetchMode()
     {
-        $this->assertEquals(PDOCrateDB::FETCH_BOTH, $this->pdo->getAttribute(PDOCrateDB::ATTR_DEFAULT_FETCH_MODE));
-        $this->pdo->setAttribute(PDOCrateDB::ATTR_DEFAULT_FETCH_MODE, PDOCrateDB::FETCH_ASSOC);
-        $this->assertEquals(PDOCrateDB::FETCH_ASSOC, $this->pdo->getAttribute(PDOCrateDB::ATTR_DEFAULT_FETCH_MODE));
+        $this->assertEquals(PDO::FETCH_BOTH, $this->pdo->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
+        $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        $this->assertEquals(PDO::FETCH_ASSOC, $this->pdo->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
     }
 
     /**
@@ -138,9 +139,9 @@ class PDOTest extends TestCase
      */
     public function testGetAndSetErrorMode()
     {
-        $this->assertEquals(PDOCrateDB::ERRMODE_SILENT, $this->pdo->getAttribute(PDOCrateDB::ATTR_ERRMODE));
-        $this->pdo->setAttribute(PDOCrateDB::ATTR_ERRMODE, PDOCrateDB::ERRMODE_EXCEPTION);
-        $this->assertEquals(PDOCrateDB::ERRMODE_EXCEPTION, $this->pdo->getAttribute(PDOCrateDB::ATTR_ERRMODE));
+        $this->assertEquals(PDO::ERRMODE_SILENT, $this->pdo->getAttribute(PDO::ATTR_ERRMODE));
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->assertEquals(PDO::ERRMODE_EXCEPTION, $this->pdo->getAttribute(PDO::ATTR_ERRMODE));
     }
 
     /**
@@ -149,9 +150,9 @@ class PDOTest extends TestCase
      */
     public function testGetAndSetStatementClass()
     {
-        $this->assertEquals([PDOStatement::class], $this->pdo->getAttribute(PDOCrateDB::ATTR_STATEMENT_CLASS));
-        $this->pdo->setAttribute(PDOCrateDB::ATTR_STATEMENT_CLASS, 'Doctrine\DBAL\Driver\PDO\Statement');
-        $this->assertEquals(['Doctrine\DBAL\Driver\PDO\Statement'], $this->pdo->getAttribute(PDOCrateDB::ATTR_STATEMENT_CLASS));
+        $this->assertEquals([PDOStatement::class], $this->pdo->getAttribute(PDO::ATTR_STATEMENT_CLASS));
+        $this->pdo->setAttribute(PDO::ATTR_STATEMENT_CLASS, 'Doctrine\DBAL\Driver\PDO\Statement');
+        $this->assertEquals(['Doctrine\DBAL\Driver\PDO\Statement'], $this->pdo->getAttribute(PDO::ATTR_STATEMENT_CLASS));
     }
 
     /**
@@ -172,7 +173,7 @@ class PDOTest extends TestCase
 
     public function testGetStatementClass()
     {
-        $this->assertEquals([PDOStatement::class], $this->pdo->getAttribute(PDOCrateDB::ATTR_STATEMENT_CLASS));
+        $this->assertEquals([PDOStatement::class], $this->pdo->getAttribute(PDO::ATTR_STATEMENT_CLASS));
     }
 
     /**
@@ -180,7 +181,7 @@ class PDOTest extends TestCase
      */
     public function testPersistent()
     {
-        $this->assertFalse($this->pdo->getAttribute(PDOCrateDB::ATTR_PERSISTENT));
+        $this->assertFalse($this->pdo->getAttribute(PDO::ATTR_PERSISTENT));
     }
 
     /**
@@ -188,7 +189,7 @@ class PDOTest extends TestCase
      */
     public function testPreFetch()
     {
-        $this->assertFalse($this->pdo->getAttribute(PDOCrateDB::ATTR_PREFETCH));
+        $this->assertFalse($this->pdo->getAttribute(PDO::ATTR_PREFETCH));
     }
 
     /**
@@ -196,7 +197,7 @@ class PDOTest extends TestCase
      */
     public function testAutoCommit()
     {
-        $this->assertTrue($this->pdo->getAttribute(PDOCrateDB::ATTR_AUTOCOMMIT));
+        $this->assertTrue($this->pdo->getAttribute(PDO::ATTR_AUTOCOMMIT));
     }
 
     /**
@@ -218,11 +219,11 @@ class PDOTest extends TestCase
     {
         $timeout = 3;
 
-        $this->assertEquals(0, $this->pdo->getAttribute(PDOCrateDB::ATTR_TIMEOUT));
+        $this->assertEquals(0, $this->pdo->getAttribute(PDO::ATTR_TIMEOUT));
 
-        $this->pdo->setAttribute(PDOCrateDB::ATTR_TIMEOUT, $timeout);
+        $this->pdo->setAttribute(PDO::ATTR_TIMEOUT, $timeout);
 
-        $this->assertEquals($timeout, $this->pdo->getAttribute(PDOCrateDB::ATTR_TIMEOUT));
+        $this->assertEquals($timeout, $this->pdo->getAttribute(PDO::ATTR_TIMEOUT));
     }
 
     /**
@@ -230,11 +231,11 @@ class PDOTest extends TestCase
      */
     public function testQuote()
     {
-        $this->assertTrue($this->pdo->quote('1', PDOCrateDB::PARAM_BOOL));
-        $this->assertFalse($this->pdo->quote('0', PDOCrateDB::PARAM_BOOL));
+        $this->assertTrue($this->pdo->quote('1', PDO::PARAM_BOOL));
+        $this->assertFalse($this->pdo->quote('0', PDO::PARAM_BOOL));
 
-        $this->assertEquals(100, $this->pdo->quote('100', PDOCrateDB::PARAM_INT));
-        $this->assertNull($this->pdo->quote('helloWorld', PDOCrateDB::PARAM_NULL));
+        $this->assertEquals(100, $this->pdo->quote('100', PDO::PARAM_INT));
+        $this->assertNull($this->pdo->quote('helloWorld', PDO::PARAM_NULL));
 
         $this->assertEquals("Don''t bother", $this->pdo->quote("Don't bother", \PDO::PARAM_STR));
     }
@@ -245,7 +246,7 @@ class PDOTest extends TestCase
     public function quoteExceptionProvider()
     {
         return [
-            [PDOCrateDB::PARAM_LOB, PDOException::class, 'This is not supported by crate.io'],
+            [PDO::PARAM_LOB, PDOException::class, 'This is not supported by crate.io'],
             [120, InvalidArgumentException::class, 'Unknown param type'],
         ];
     }
@@ -350,11 +351,11 @@ class PDOTest extends TestCase
     public function fetchModeStyleProvider()
     {
         return [
-            [PDOCrateDB::FETCH_ASSOC],
-            [PDOCrateDB::FETCH_NUM],
-            [PDOCrateDB::FETCH_BOTH],
-            [PDOCrateDB::FETCH_BOUND],
-            [PDOCrateDB::FETCH_NAMED],
+            [PDO::FETCH_ASSOC],
+            [PDO::FETCH_NUM],
+            [PDO::FETCH_BOTH],
+            [PDO::FETCH_BOUND],
+            [PDO::FETCH_NAMED],
         ];
     }
 


### PR DESCRIPTION
## About
Let's refer to `PDOCrateDB::` symbols only for CrateDB specifics, but use `PDO::` everywhere else.

## Details
This emphasizes general standards compliance and helps navigating the code base to better identify spots where CrateDB actually needs to have specific implementations, while all other spots don't differ from canonical PDO at all.
