### PR TITLE
Chore: Don't erroneously flag valid PDO methods as "deprecated"

### DIFF
--- a/src/Crate/PDO/PDOStatementImplementationPhp7.php
+++ b/src/Crate/PDO/PDOStatementImplementationPhp7.php
@@ -32,7 +32,7 @@ use function func_get_args;
 trait PDOStatementImplementationPhp7
 {
     /**
-     * @deprecated Use one of the fetch- or iterate-related methods.
+     * Set the default fetch mode for this statement.
      *
      * @param int   $fetchMode
      * @param mixed $arg2
@@ -44,7 +44,7 @@ trait PDOStatementImplementationPhp7
     }
 
     /**
-     * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchFirstColumn() instead.
+     * Fetch the remaining rows from a result set.
      *
      * @param int|null $fetchMode
      * @param mixed    $fetchArgument

--- a/src/Crate/PDO/PDOStatementImplementationPhp8.php
+++ b/src/Crate/PDO/PDOStatementImplementationPhp8.php
@@ -30,7 +30,7 @@ namespace Crate\PDO;
 trait PDOStatementImplementationPhp8
 {
     /**
-     * @deprecated Use one of the fetch- or iterate-related methods.
+     * Set the default fetch mode for this statement.
      *
      * @param int   $mode
      * @param mixed ...$args
@@ -44,7 +44,7 @@ trait PDOStatementImplementationPhp8
     }
 
     /**
-     * @deprecated Use fetchAllNumeric(), fetchAllAssociative() or fetchFirstColumn() instead.
+     * Fetch the remaining rows from a result set.
      *
      * @param int|null $mode
      * @param mixed    ...$args


### PR DESCRIPTION
## About
There was a misguidance that slipped in from the new Doctrine DBAL API, and has nothing to do with PDO. This patch removes it.

## Details
- https://www.php.net/manual/en/pdostatement.fetchall.php
- https://www.php.net/manual/en/pdostatement.setfetchmode.php

## References
- GH-144